### PR TITLE
fix: guard against None in generate_schema_name macro

### DIFF
--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,5 +1,10 @@
 {% macro generate_schema_name(custom_schema_name, node) -%}
 
-   {{ custom_schema_name | trim }}
+    {%- set default_schema = target.schema -%}
+    {%- if custom_schema_name is none -%}
+        {{ default_schema }}
+    {%- else -%}
+        {{ custom_schema_name | trim }}
+    {%- endif -%}
 
 {%- endmacro %}


### PR DESCRIPTION
dbt_query_tags models (and any package model without an explicit +schema: config) pass Jinja 'none' as custom_schema_name. The previous implementation called '| trim' unconditionally, which rendered the literal string 'None' — causing failures like:

  describe table CDO_CUR.None.stg_sources...
  describe table MD_CUR_PD.None.stg_metrics...

Fix: add an 'is none' guard and fall back to target.schema, matching dbt's own default generate_schema_name behaviour while preserving the custom-schema-as-is override for all models that do set +schema:.

Fixes: DPSA-321 (dbt_query_tags None schema resolution)