### PR TITLE
skip ephemeral

### DIFF
--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -7,6 +7,11 @@
                require an explicit schema — fall back to target.schema silently. #}
             {{ target.schema }}
 
+        {%- elif node.config.materialized == 'ephemeral' -%}
+            {# Ephemeral models are inlined at compile time and never written to the
+               warehouse, so they have no schema requirement. Skip enforcement. #}
+            {{ target.schema }}
+
         {%- elif node.package_name == 'dbt_project_evaluator' -%}
             {# Force dbt_project_evaluator models to UTIL_COMMON.
                The CI Python script injects +schema at build time, but this macro


### PR DESCRIPTION
This pull request updates the custom schema selection logic in the `get_custom_schema.sql` macro to better handle ephemeral models. The main change ensures that ephemeral models, which are inlined and not written to the data warehouse, do not require schema enforcement.

Schema handling improvement:

* Updated `get_custom_schema.sql` to skip schema enforcement for models with `materialized` set to `ephemeral`, defaulting to `target.schema` for these cases. This avoids unnecessary schema checks for ephemeral models, which are not persisted in the warehouse.