### PR TITLE
feat(DPSA-366): skip on-run-end hooks for SBX databases

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,5 +29,5 @@ models:
 
 # Automatically reapply Snowflake tags after every dbt run (fixes tag loss on view recreation)
 on-run-end:
-  - "{{ cp_dbt_standard_package.tag_models_from_results() }}"
-  - "{{ cp_dbt_standard_package.call_certified_read_proc() }}"
+  - "{% if 'SBX' not in target.database | upper %}{{ cp_dbt_standard_package.tag_models_from_results() }}{% endif %}"
+  - "{% if 'SBX' not in target.database | upper %}{{ cp_dbt_standard_package.call_certified_read_proc() }}{% endif %}"


### PR DESCRIPTION
- Guard tag_models_from_results() and call_certified_read_proc() macros with 'SBX' not in target.database check to prevent tag/grant operations against sandbox databases
- Mirror the same guard in dbt_project.yml on-run-end hooks