### PR TITLE
fix(DPB-2472): project-scoped warehouse lookup in set_query_tag

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -7,7 +7,12 @@
     ) %}
     
     {% set airflow_run = env_var('AIRFLOW_RUN', 'true') %}
-    {% set where_statement = "source_uri = '" ~ model.name ~ "' and airflow = '" ~ airflow_run ~ "'" %}  
+    {#
+      Filter by both model name AND dbt project so that models sharing the same name
+      across projects (e.g. mkt.fct_sales vs itt.fct_sales) resolve to the correct
+      warehouse size for their own project.
+    #}
+    {% set where_statement = "source_uri = '" ~ model.name ~ "' and dbt_project = '" ~ project_name ~ "' and airflow = '" ~ airflow_run ~ "'" %}
 
     {% set warehouse = dbt_utils.get_column_values(
         relation, 
@@ -15,12 +20,27 @@
         default=['CP_DBT_LARGE_WH_V2'], 
         where=where_statement
     ) %}
+    {#
+      Fallback: project-scoped row doesn't exist yet (e.g. during the transition period
+      before dbt_project values have accumulated in the sizing table). Retry with
+      model name only so existing behaviour is preserved.
+    #}
+    {% if not warehouse or warehouse == ['CP_DBT_LARGE_WH_V2'] %}
+        {% set fallback_where = "source_uri = '" ~ model.name ~ "' and airflow = '" ~ airflow_run ~ "'" %}
+        {% set warehouse = dbt_utils.get_column_values(
+            relation,
+            'RECOMMENDED_WAREHOUSE_NAME',
+            default=['CP_DBT_LARGE_WH_V2'],
+            where=fallback_where
+        ) %}
+    {% endif %}
     {% set warehouseName = warehouse[0] if warehouse else 'CP_DBT_LARGE_WH_V2' %}
     
     {% set merged_extra = extra.copy() %}
     {% do merged_extra.update({
         'invocation_id': invocation_id, 
-        'model': model.name, 
+        'model': model.name,
+        'dbt_project': project_name,
         'is_airflow_run': airflow_run
     }) %}
     


### PR DESCRIPTION
## Jira
[DPB-2472](https://colpal.atlassian.net/browse/DPB-2472)

## ⚠️ Merge Order — This PR must be merged SECOND

**Do not merge until [PR 1 — analytics-ops#488](https://github.com/colpal/analytics-ops/pull/488) has been merged AND the `dbt_project` column is confirmed in production:**

```sql
DESCRIBE TABLE OPS_CUR.WH_RECOMMENDATIONS.INT_WAREHOUSE_RECOMMENDATION;
-- Must see dbt_project column before merging this PR
```

Merging before the column exists causes a SQL compilation error that breaks all V2 domain builds simultaneously.

## Problem

`set_query_tag` filters the sizing table on `model_name` only. When two projects have models with the same name, the macro picks whichever row comes back first — e.g. `mkt.fct_sales` (6XL) gets sized as `X-SMALL` because `itt.fct_sales` shares the same name and needs `X-SMALL`.

## What Changed

- **WHERE clause** now includes `dbt_project = project_name` so lookups are scoped to the calling project.
- **Fallback** retained for the transition period: if no project-scoped row exists yet (rows from before this fix have `dbt_project = ''`), the macro retries with model name only — no degradation during migration.
- **`merged_extra`** now includes `dbt_project` so it is emitted in the Snowflake query tag, enabling the sizing model (`int_warehouse_recommendation`) to store per-project rows going forward.

## After Merge

After merging and tagging on `release/v2`, all analytics-* domain repos pick up the new macro on their next CI run. Within one Airflow cycle (~3h), project-specific rows are inserted into `INT_WAREHOUSE_RECOMMENDATION`. A follow-up `DELETE WHERE dbt_project = ''` cleans up orphan rows.

## Related PRs (in merge order)

1. `analytics-ops` → `master`: [PR#488](https://github.com/colpal/analytics-ops/pull/488) — **must be merged and confirmed before this PR**
2. **This PR** — merge after PR#488 confirmed in production
3. `dbt-common` → `release/v2`: [bugfix/DPB-2473.lint-gate](https://github.com/colpal/dbt-common) — DPB-2473, independent

[DPB-2472]: https://cp9.atlassian.net/browse/DPB-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ