### PR TITLE
fix(DPB-2494): prevent drop_unneeded_objects from dropping dynamic tables

### DIFF
--- a/macros/cp_drop_unneeded_objects.sql
+++ b/macros/cp_drop_unneeded_objects.sql
@@ -12,7 +12,7 @@
 
 {% set current_models_type=[] %}
 {%- for model in models_type -%}
-    {% do current_models_type.append(model | replace(".seed",".table") | replace(".incremental",".table") | replace(".snapshot",".table")) %} 
+    {% do current_models_type.append(model | replace(".seed",".table") | replace(".incremental",".table") | replace(".snapshot",".table") | replace(".dynamic_table",".table")) %} 
 {%- endfor -%}
 
 --Run a query to create the drop statements for all relations in snowflake that are NOT in the dbt project

--- a/macros/drop_unneeded_objects.sql
+++ b/macros/drop_unneeded_objects.sql
@@ -12,7 +12,7 @@
 
 {% set current_models_type=[] %}
 {%- for model in models_type -%}
-    {% do current_models_type.append(model | replace(".seed",".table") | replace(".incremental",".table") | replace(".snapshot",".table")) %} 
+    {% do current_models_type.append(model | replace(".seed",".table") | replace(".incremental",".table") | replace(".snapshot",".table") | replace(".dynamic_table",".table")) %} 
 {%- endfor -%}
 
 --Run a query to create the drop statements for all relations in snowflake that are NOT in the dbt project


### PR DESCRIPTION
Dynamic tables appear as 'BASE TABLE' in information_schema.tables, producing sf_tabnm_type = 'MODEL.TABLE'. But dbt config.materialized is 'dynamic_table', which was not normalized by the replace chain, causing a false materialization mismatch that triggers DROP TABLE.

This PR adds dynamic tables to the list of registered dbt model types.