### PR TITLE
dpb-2503 - iceberg overrides handle sync_all_columns and array data type

### DIFF
--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -27,7 +27,7 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 {% endmacro %}
 
 {% macro default__render_raw_columns_constraints(raw_columns) %}
-            {{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__render_raw_columns_constraints(raw_columns) %}
@@ -40,10 +40,10 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro snowflake__get_tmp_relation_type(strategy, unique_key, language) %}
-{%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
-{%- if catalog_relation is not none and catalog_relation.catalog_type == 'BUILT_IN' -%}
+    {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+        {%- if catalog_relation is not none and catalog_relation.catalog_type == 'BUILT_IN' -%}
             {{ return("table") }}
-{%- endif -%}
+        {%- endif -%}
 
 {#-- Catch Iceberg models if catalog_relation fails to build --#}
 {%- if config.get('catalog_name') is not none or config.get('table_format') == 'iceberg' -%}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -11,27 +11,27 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro get_table_columns_and_constraints() %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro default__get_table_columns_and_constraints() %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__get_table_columns_and_constraints() %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro render_raw_columns_constraints(raw_columns) %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro default__render_raw_columns_constraints(raw_columns) %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__render_raw_columns_constraints(raw_columns) %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 
@@ -40,24 +40,24 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro snowflake__get_tmp_relation_type(strategy, unique_key, language) %}
-    {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
-    {%- if catalog_relation is not none and catalog_relation.catalog_type == 'BUILT_IN' -%}
-        {{ return("table") }}
-    {%- endif -%}
+{%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+{%- if catalog_relation is not none and catalog_relation.catalog_type == 'BUILT_IN' -%}
+{{ return("table") }}
+{%- endif -%}
 
-    {#-- Catch Iceberg models if catalog_relation fails to build --#}
-    {%- if config.get('catalog_name') is not none or config.get('table_format') == 'iceberg' -%}
-        {{ return("table") }}
-    {%- endif -%}
+{#-- Catch Iceberg models if catalog_relation fails to build --#}
+{%- if config.get('catalog_name') is not none or config.get('table_format') == 'iceberg' -%}
+{{ return("table") }}
+{%- endif -%}
 
-    {#-- For non-Iceberg models, use native logic --#}
-    {%- set tmp_relation_type = config.get('tmp_relation_type') -%}
+{#-- For non-Iceberg models, use native logic --#}
+{%- set tmp_relation_type = config.get('tmp_relation_type') -%}
 
-    {% if snowflake__is_catalog_linked_database(relation=config.model) %}
-        {{ return("table") }}
-    {% endif %}
+{% if snowflake__is_catalog_linked_database(relation=config.model) %}
+{{ return("table") }}
+{% endif %}
 
-    {% if language != "sql" %}
+{% if language != "sql" %}
         {{ return("table") }}
     {% elif tmp_relation_type == "table" %}
         {{ return("table") }}
@@ -68,8 +68,8 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
     {% elif strategy in ["delete+insert", "microbatch"] and unique_key is none %}
         {{ return("view") }}
     {% else %}
-        {{ return("table") }}
-    {% endif %}
+{{ return("table") }}
+{% endif %}
 {% endmacro %}
 
 
@@ -78,78 +78,88 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
-    {% if language == 'sql' and not temporary %}
-        {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
+    {%- set is_iceberg = (
+        config.get('catalog_name') is not none
+        or config.get('table_format', '') | lower == 'iceberg'
+    ) -%}
+
+{% if language == 'sql' and (not temporary or is_iceberg) %}
+{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
         
-        {% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
-        
-        {% if execute %}
-            {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-            {% do run_query(create_temp_sql) %}
-        {% endif %}
-        
-        {% set final_sql = "SELECT * FROM " ~ pre_relation %}
-        {{ return(dbt.snowflake__create_table_as(temporary, relation, final_sql, language)) }}
+{%- if not temporary -%}
+{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
+            
+{% if execute %}
+                {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
+                {% do run_query(create_temp_sql) %}
+            {% endif %}
+            
+            {% set final_sql = "SELECT * FROM " ~ pre_relation %}
+            {{ return(dbt.snowflake__create_table_as(temporary, relation, final_sql, language)) }}
+        {%- else -%}
+            {#-- Temporary staging table for incremental Iceberg: wrap directly, no extra pre-table needed --#}
+            {{ return(dbt.snowflake__create_table_as(temporary, relation, safe_sql, language)) }}
+        {%- endif -%}
     {% else %}
-        {{ return(dbt.snowflake__create_table_as(temporary, relation, compiled_code, language)) }}
-    {% endif %}
+{{ return(dbt.snowflake__create_table_as(temporary, relation, compiled_code, language)) }}
+{% endif %}
 {%- endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}
-    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-    {{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
+{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+{{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
 {%- endmacro %}
 
 {% macro snowflake__get_create_view_as_sql(relation, sql) -%}
-    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-    {{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
+{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+{{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
 {%- endmacro %}
 
 {% macro snowflake__get_create_table_as_sql(temporary, relation, sql) -%}
-    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
     
-    {% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
+{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
     
-    {% if execute %}
-        {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-        {% do run_query(create_temp_sql) %}
-    {% endif %}
+{% if execute %}
+{% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
+{% do run_query(create_temp_sql) %}
+{% endif %}
     
-    {% set final_sql = "SELECT * FROM " ~ pre_relation %}
+{% set final_sql = "SELECT * FROM " ~ pre_relation %}
     
-    {% if 'snowflake__get_create_table_as_sql' in dbt %}
+{% if 'snowflake__get_create_table_as_sql' in dbt %}
         {{ return(dbt.snowflake__get_create_table_as_sql(temporary, relation, final_sql)) }}
     {% else %}
-        {{ return(dbt.default__get_create_table_as_sql(temporary, relation, final_sql)) }}
-    {% endif %}
+{{ return(dbt.default__get_create_table_as_sql(temporary, relation, final_sql)) }}
+{% endif %}
 {%- endmacro %}
 
 {% macro snowflake__get_create_iceberg_table_as_sql(temporary, relation, sql) -%}
-    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
     
-    {% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
+{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
     
-    {% if execute %}
-        {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-        {% do run_query(create_temp_sql) %}
-    {% endif %}
+{% if execute %}
+{% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
+{% do run_query(create_temp_sql) %}
+{% endif %}
     
-    {% set final_sql = "SELECT * FROM " ~ pre_relation %}
+{% set final_sql = "SELECT * FROM " ~ pre_relation %}
     
-    {% if 'snowflake__get_create_iceberg_table_as_sql' in dbt %}
+{% if 'snowflake__get_create_iceberg_table_as_sql' in dbt %}
         {{ return(dbt.snowflake__get_create_iceberg_table_as_sql(temporary, relation, final_sql)) }}
     {% else %}
-        {{ return(dbt.default__get_create_table_as_sql(temporary, relation, final_sql)) }}
-    {% endif %}
+{{ return(dbt.default__get_create_table_as_sql(temporary, relation, final_sql)) }}
+{% endif %}
 {%- endmacro %}
 
 {% macro snowflake__create_iceberg_table_as(temporary, relation, compiled_code, language='sql') -%}
-    {% if language == 'sql' %}
-        {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
+{% if language == 'sql' %}
+{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
         
-        {% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
+{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
         
-        {% if execute %}
+{% if execute %}
             {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
             {% do run_query(create_temp_sql) %}
         {% endif %}
@@ -157,8 +167,8 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
         {% set final_sql = "SELECT * FROM " ~ pre_relation %}
         {{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, final_sql, language)) }}
     {% else %}
-        {{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, compiled_code, language)) }}
-    {% endif %}
+{{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, compiled_code, language)) }}
+{% endif %}
 {%- endmacro %}
 
 
@@ -167,15 +177,15 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro get_assert_columns_equivalent(ddl_dict) %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro default__get_assert_columns_equivalent(ddl_dict) %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__get_assert_columns_equivalent(ddl_dict) %}
-    {{ return('') }}
+{{ return('') }}
 {% endmacro %}
 
 
@@ -184,22 +194,22 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro iceberg_type_safe_wrap(compiled_code) %}
-    {%- set temp_view = make_temp_relation(this).incorporate(type='view') -%}
+{%- set temp_view = make_temp_relation(this).incorporate(type='view') -%}
 
-    {% call statement('create_type_introspection_view') %}
-        {{ config.get('sql_header', '') }}
+{% call statement('create_type_introspection_view') %}
+{{ config.get('sql_header', '') }}
         CREATE OR REPLACE VIEW {{ temp_view }} AS (
 {{ compiled_code }}
 )
     {% endcall %}
 
-    {%- set describe_sql = "DESCRIBE VIEW " ~ temp_view -%}
-    {%- set results = run_query(describe_sql) -%}
+{%- set describe_sql = "DESCRIBE VIEW " ~ temp_view -%}
+{%- set results = run_query(describe_sql) -%}
 
-    {%- set needs_casting = [] -%}
-    {%- set final_columns = [] -%}
+{%- set needs_casting = [] -%}
+{%- set final_columns = [] -%}
 
-    {%- if execute -%}
+{%- if execute -%}
         {%- for row in results.rows -%}
             {%- set col_name = row['name'] -%}
             {%- set col_type = row['type'] | string | upper -%}
@@ -214,24 +224,24 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
         {%- endfor -%}
     {%- endif -%}
 
-    {% call statement('drop_type_introspection_view') %}
+{% call statement('drop_type_introspection_view') %}
         DROP VIEW IF EXISTS {{ temp_view }}
-    {% endcall %}
+{% endcall %}
 
-    {%- if needs_casting | length == 0 -%}
+{%- if needs_casting | length == 0 -%}
         {{ return(compiled_code) }}
     {%- endif -%}
 
-    {%- set safe_sql -%}
+{%- set safe_sql -%}
         SELECT
         {% for col in final_columns %}
-            {%- set col_name = col.name -%}
-            {%- set col_type = col.type -%}
-            {%- set stripped_type = col_type | replace(" ", "") -%}
-            {%- set is_unspecified_number = ('NUMBER' in col_type or 'DECIMAL' in col_type or 'NUMERIC' in col_type) and ('(' not in col_type or '38,0' in stripped_type) -%}
-            {%- set has_colon = ':' in col_name -%}
+{%- set col_name = col.name -%}
+{%- set col_type = col.type -%}
+{%- set stripped_type = col_type | replace(" ", "") -%}
+{%- set is_unspecified_number = ('NUMBER' in col_type or 'DECIMAL' in col_type or 'NUMERIC' in col_type) and ('(' not in col_type or '38,0' in stripped_type) -%}
+{%- set has_colon = ':' in col_name -%}
 
-            {%- if has_colon -%}
+{%- if has_colon -%}
                 "{{ col_name }}"
             {%- elif 'TIMESTAMP_LTZ' in col_type -%}
                 CAST("{{ col_name }}" AS TIMESTAMP_LTZ(6)) AS "{{ col_name }}"
@@ -254,14 +264,14 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
             {%- elif is_unspecified_number -%}
                 CAST("{{ col_name }}" AS NUMBER(38, 0)) AS "{{ col_name }}"
             {%- else -%}
-                "{{ col_name }}"
-            {%- endif -%}
-            {%- if not loop.last -%}, {% endif -%}
-        {%- endfor %}
+"{{ col_name }}"
+{%- endif -%}
+{%- if not loop.last -%}, {% endif -%}
+{%- endfor %}
         FROM (
             {{ compiled_code }}
         ) AS __iceberg_type_safe_source
-    {%- endset -%}
+{%- endset -%}
 
-    {{ return(safe_sql) }}
+{{ return(safe_sql) }}
 {% endmacro %}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -40,9 +40,10 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro snowflake__get_tmp_relation_type(strategy, unique_key, language) %}
+            {{ log("DEBUG: catalog_name=" ~ config.get('catalog_name') ~ " | catalog_relation=" ~ catalog_relation ~ " | strategy=" ~ strategy, info=True) }}
 {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 {%- if catalog_relation is not none and catalog_relation.catalog_type == 'BUILT_IN' -%}
-{{ return("table") }}
+            {{ return("table") }}
 {%- endif -%}
 
 {#-- Catch Iceberg models if catalog_relation fails to build --#}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -83,7 +83,7 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
         or config.get('table_format', '') | lower == 'iceberg'
     ) -%}
 
-{% if language == 'sql' and (not temporary or is_iceberg) %}
+{% if language == 'sql' and is_iceberg) %}
 {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
         
 {%- if not temporary -%}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -101,8 +101,8 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
             {{ return(dbt.snowflake__create_table_as(temporary, relation, safe_sql, language)) }}
         {%- endif -%}
     {% else %}
-{{ return(dbt.snowflake__create_table_as(temporary, relation, compiled_code, language)) }}
-{% endif %}
+        {{ return(dbt.snowflake__create_table_as(temporary, relation, compiled_code, language)) }}
+    {% endif %}
 {%- endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}
@@ -116,12 +116,12 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 {%- endmacro %}
 
 {% macro snowflake__get_create_view_as_sql(relation, sql) -%}
-{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-{{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
+    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+    {{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
 {%- endmacro %}
 
 {% macro snowflake__get_create_table_as_sql(temporary, relation, sql) -%}
-{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
     
 {% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
     
@@ -140,14 +140,14 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 {%- endmacro %}
 
 {% macro snowflake__get_create_iceberg_table_as_sql(temporary, relation, sql) -%}
-{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+    {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
     
 {% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
     
-{% if execute %}
-{% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-{% do run_query(create_temp_sql) %}
-{% endif %}
+    {% if execute %}
+        {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
+        {% do run_query(create_temp_sql) %}
+    {% endif %}
     
 {% set final_sql = "SELECT * FROM " ~ pre_relation %}
     

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -3,8 +3,6 @@
 MACRO FILE: iceberg_overrides.sql
 PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to 
             enforce Apache Iceberg type safety and bypass strict contract errors.
-            Updated: final Iceberg tables are now created directly from
-            type-safe SQL (no __dbt_pre temp table hop) for better performance.
 ===============================================================================
 #}
 
@@ -79,7 +77,7 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    SECTION 3: MATERIALIZATION OVERRIDES (Safe Temp Table Routing)
    ============================================================================ #}
 
-{# NOTE: Final tables are created directly from safe_sql (no __dbt_pre) #}
+{# NOTE: Final tables are created directly from safe_sql #}
 
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
     {%- set is_iceberg = (
@@ -213,15 +211,15 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro get_assert_columns_equivalent(ddl_dict) %}
-{{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro default__get_assert_columns_equivalent(ddl_dict) %}
-{{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__get_assert_columns_equivalent(ddl_dict) %}
-{{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 
@@ -230,22 +228,22 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro iceberg_type_safe_wrap(compiled_code) %}
-{%- set temp_view = make_temp_relation(this).incorporate(type='view') -%}
+    {%- set temp_view = make_temp_relation(this).incorporate(type='view') -%}
 
-{% call statement('create_type_introspection_view') %}
-{{ config.get('sql_header', '') }}
+    {% call statement('create_type_introspection_view') %}
+        {{ config.get('sql_header', '') }}
         CREATE OR REPLACE VIEW {{ temp_view }} AS (
-{{ compiled_code }}
-)
+        {{ compiled_code }}
+        )
     {% endcall %}
 
-{%- set describe_sql = "DESCRIBE VIEW " ~ temp_view -%}
-{%- set results = run_query(describe_sql) -%}
+    {%- set describe_sql = "DESCRIBE VIEW " ~ temp_view -%}
+    {%- set results = run_query(describe_sql) -%}
 
-{%- set needs_casting = [] -%}
-{%- set final_columns = [] -%}
+    {%- set needs_casting = [] -%}
+    {%- set final_columns = [] -%}
 
-{%- if execute -%}
+    {%- if execute -%}
         {%- for row in results.rows -%}
             {%- set col_name = row['name'] -%}
             {%- set col_type = row['type'] | string | upper -%}
@@ -260,24 +258,24 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
         {%- endfor -%}
     {%- endif -%}
 
-{% call statement('drop_type_introspection_view') %}
+    {% call statement('drop_type_introspection_view') %}
         DROP VIEW IF EXISTS {{ temp_view }}
-{% endcall %}
+    {% endcall %}
 
-{%- if needs_casting | length == 0 -%}
+    {%- if needs_casting | length == 0 -%}
         {{ return(compiled_code) }}
     {%- endif -%}
 
-{%- set safe_sql -%}
+    {%- set safe_sql -%}
         SELECT
         {% for col in final_columns %}
-{%- set col_name = col.name -%}
-{%- set col_type = col.type -%}
-{%- set stripped_type = col_type | replace(" ", "") -%}
-{%- set is_unspecified_number = ('NUMBER' in col_type or 'DECIMAL' in col_type or 'NUMERIC' in col_type) and ('(' not in col_type or '38,0' in stripped_type) -%}
-{%- set has_colon = ':' in col_name -%}
+            {%- set col_name = col.name -%}
+            {%- set col_type = col.type -%}
+            {%- set stripped_type = col_type | replace(" ", "") -%}
+            {%- set is_unspecified_number = ('NUMBER' in col_type or 'DECIMAL' in col_type or 'NUMERIC' in col_type) and ('(' not in col_type or '38,0' in stripped_type) -%}
+            {%- set has_colon = ':' in col_name -%}
 
-{%- if has_colon -%}
+            {%- if has_colon -%}
                 "{{ col_name }}"
             {%- elif 'TIMESTAMP_LTZ' in col_type -%}
                 CAST("{{ col_name }}" AS TIMESTAMP_LTZ(6)) AS "{{ col_name }}"
@@ -300,14 +298,14 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
             {%- elif is_unspecified_number -%}
                 CAST("{{ col_name }}" AS NUMBER(38, 0)) AS "{{ col_name }}"
             {%- else -%}
-"{{ col_name }}"
-{%- endif -%}
-{%- if not loop.last -%}, {% endif -%}
-{%- endfor %}
+                "{{ col_name }}"
+            {%- endif -%}
+            {%- if not loop.last -%}, {% endif -%}
+        {%- endfor %}
         FROM (
             {{ compiled_code }}
         ) AS __iceberg_type_safe_source
-{%- endset -%}
+    {%- endset -%}
 
-{{ return(safe_sql) }}
+    {{ return(safe_sql) }}
 {% endmacro %}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -208,12 +208,12 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
         {%- set create_safe_sql = "CREATE OR REPLACE TEMPORARY VIEW " ~ safe_source ~ " AS SELECT " ~ wrapped_cols | join(", ") ~ " FROM " ~ source -%}
         {%- do run_query(create_safe_sql) -%}
 
-        {{ return(dbt.get_merge_sql(target, safe_source, unique_key, dest_columns, incremental_predicates)) }}
+        {{ return(dbt.snowflake__get_merge_sql(target, safe_source, unique_key, dest_columns, incremental_predicates)) }}
     {%- else -%}
-        {{ return(dbt.get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) }}
+        {{ return(dbt.snowflake__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) }}
     {%- endif -%}
 {%- else -%}
-    {{ return(dbt.get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) }}
+    {{ return(dbt.snowflake__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) }}
 {%- endif -%}
 {% endmacro %}
 

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -3,6 +3,8 @@
 MACRO FILE: iceberg_overrides.sql
 PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to 
             enforce Apache Iceberg type safety and bypass strict contract errors.
+            Updated: final Iceberg tables are now created directly from
+            type-safe SQL (no __dbt_pre temp table hop) for better performance.
 ===============================================================================
 #}
 
@@ -45,19 +47,19 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
             {{ return("table") }}
         {%- endif -%}
 
-{#-- Catch Iceberg models if catalog_relation fails to build --#}
-{%- if config.get('catalog_name') is not none or config.get('table_format') == 'iceberg' -%}
-{{ return("table") }}
-{%- endif -%}
+    {#-- Catch Iceberg models if catalog_relation fails to build --#}
+    {%- if config.get('catalog_name') is not none or config.get('table_format') == 'iceberg' -%}
+        {{ return("table") }}
+    {%- endif -%}
 
-{#-- For non-Iceberg models, use native logic --#}
-{%- set tmp_relation_type = config.get('tmp_relation_type') -%}
+    {#-- For non-Iceberg models, use native logic --#}
+    {%- set tmp_relation_type = config.get('tmp_relation_type') -%}
 
-{% if snowflake__is_catalog_linked_database(relation=config.model) %}
-{{ return("table") }}
-{% endif %}
+    {% if snowflake__is_catalog_linked_database(relation=config.model) %}
+        {{ return("table") }}
+    {% endif %}
 
-{% if language != "sql" %}
+    {% if language != "sql" %}
         {{ return("table") }}
     {% elif tmp_relation_type == "table" %}
         {{ return("table") }}
@@ -68,8 +70,8 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
     {% elif strategy in ["delete+insert", "microbatch"] and unique_key is none %}
         {{ return("view") }}
     {% else %}
-{{ return("table") }}
-{% endif %}
+        {{ return("table") }}
+    {% endif %}
 {% endmacro %}
 
 
@@ -77,42 +79,30 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    SECTION 3: MATERIALIZATION OVERRIDES (Safe Temp Table Routing)
    ============================================================================ #}
 
+{# NOTE: Final tables are created directly from safe_sql (no __dbt_pre) #}
+
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
     {%- set is_iceberg = (
         config.get('catalog_name') is not none
         or config.get('table_format', '') | lower == 'iceberg'
     ) -%}
 
-{% if language == 'sql' and is_iceberg %}
-{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
-        
-{%- if not temporary -%}
-{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
-            
-{% if execute %}
-                {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-                {% do run_query(create_temp_sql) %}
-            {% endif %}
-            
-            {% set final_sql = "SELECT * FROM " ~ pre_relation %}
-            {{ return(dbt.snowflake__create_table_as(temporary, relation, final_sql, language)) }}
-        {%- else -%}
-            {#-- Temporary staging table for incremental Iceberg: wrap directly, no extra pre-table needed --#}
-            {{ return(dbt.snowflake__create_table_as(temporary, relation, safe_sql, language)) }}
-        {%- endif -%}
+    {% if language == 'sql' and is_iceberg %}
+        {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
+        {{ return(dbt.snowflake__create_table_as(temporary, relation, safe_sql, language)) }}
     {% else %}
         {{ return(dbt.snowflake__create_table_as(temporary, relation, compiled_code, language)) }}
     {% endif %}
 {%- endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}
-{%- set is_iceberg = (config.get('catalog_name') is not none or config.get('table_format', '') | lower == 'iceberg') -%}
-{% if is_iceberg %}
-  {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-  {{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
-{% else %}
-  {{ return(dbt.snowflake__create_view_as(relation, sql)) }}
-{% endif %}
+    {%- set is_iceberg = (config.get('catalog_name') is not none or config.get('table_format', '') | lower == 'iceberg') -%}
+    {% if is_iceberg %}
+      {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+      {{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
+    {% else %}
+      {{ return(dbt.snowflake__create_view_as(relation, sql)) }}
+    {% endif %}
 {%- endmacro %}
 
 {% macro snowflake__get_create_view_as_sql(relation, sql) -%}
@@ -122,58 +112,31 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 
 {% macro snowflake__get_create_table_as_sql(temporary, relation, sql) -%}
     {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-    
-{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
-    
-{% if execute %}
-{% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-{% do run_query(create_temp_sql) %}
-{% endif %}
-    
-{% set final_sql = "SELECT * FROM " ~ pre_relation %}
-    
-{% if 'snowflake__get_create_table_as_sql' in dbt %}
-        {{ return(dbt.snowflake__get_create_table_as_sql(temporary, relation, final_sql)) }}
-    {% else %}
-{{ return(dbt.default__get_create_table_as_sql(temporary, relation, final_sql)) }}
-{% endif %}
+
+    {%- if 'snowflake__get_create_table_as_sql' in dbt -%}
+        {{ return(dbt.snowflake__get_create_table_as_sql(temporary, relation, safe_sql)) }}
+    {%- else -%}
+        {{ return(dbt.default__get_create_table_as_sql(temporary, relation, safe_sql)) }}
+    {%- endif -%}
 {%- endmacro %}
 
 {% macro snowflake__get_create_iceberg_table_as_sql(temporary, relation, sql) -%}
     {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-    
-{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
-    
-    {% if execute %}
-        {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-        {% do run_query(create_temp_sql) %}
-    {% endif %}
-    
-{% set final_sql = "SELECT * FROM " ~ pre_relation %}
-    
-{% if 'snowflake__get_create_iceberg_table_as_sql' in dbt %}
-        {{ return(dbt.snowflake__get_create_iceberg_table_as_sql(temporary, relation, final_sql)) }}
-    {% else %}
-{{ return(dbt.default__get_create_table_as_sql(temporary, relation, final_sql)) }}
-{% endif %}
+
+    {%- if 'snowflake__get_create_iceberg_table_as_sql' in dbt -%}
+        {{ return(dbt.snowflake__get_create_iceberg_table_as_sql(temporary, relation, safe_sql)) }}
+    {%- else -%}
+        {{ return(dbt.default__get_create_table_as_sql(temporary, relation, safe_sql)) }}
+    {%- endif -%}
 {%- endmacro %}
 
 {% macro snowflake__create_iceberg_table_as(temporary, relation, compiled_code, language='sql') -%}
-{% if language == 'sql' %}
-{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
-        
-{% set pre_relation = relation.incorporate(path={"identifier": relation.identifier ~ "__dbt_pre"}) %}
-        
-{% if execute %}
-            {% set create_temp_sql = "CREATE OR REPLACE TEMPORARY TABLE " ~ pre_relation ~ " AS \n" ~ safe_sql %}
-            {% do run_query(create_temp_sql) %}
-        {% endif %}
-        
-        {% set final_sql = "SELECT * FROM " ~ pre_relation %}
-        {{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, final_sql, language)) }}
+    {% if language == 'sql' %}
+        {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
+        {{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, safe_sql, language)) }}
     {% else %}
-{{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, compiled_code, language)) }}
-{% endif %}
+        {{ return(dbt.snowflake__create_iceberg_table_as(temporary, relation, compiled_code, language)) }}
+    {% endif %}
 {%- endmacro %}
 
 

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -83,7 +83,7 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
         or config.get('table_format', '') | lower == 'iceberg'
     ) -%}
 
-{% if language == 'sql' and is_iceberg) %}
+{% if language == 'sql' and is_iceberg %}
 {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(compiled_code) %}
         
 {%- if not temporary -%}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -11,19 +11,19 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro get_table_columns_and_constraints() %}
-            {{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro default__get_table_columns_and_constraints() %}
-            {{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__get_table_columns_and_constraints() %}
-            {{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro render_raw_columns_constraints(raw_columns) %}
-            {{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 {% macro default__render_raw_columns_constraints(raw_columns) %}
@@ -31,7 +31,7 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 {% endmacro %}
 
 {% macro snowflake__render_raw_columns_constraints(raw_columns) %}
-            {{ return('') }}
+    {{ return('') }}
 {% endmacro %}
 
 
@@ -40,7 +40,6 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro snowflake__get_tmp_relation_type(strategy, unique_key, language) %}
-            {{ log("DEBUG: catalog_name=" ~ config.get('catalog_name') ~ " | catalog_relation=" ~ catalog_relation ~ " | strategy=" ~ strategy, info=True) }}
 {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 {%- if catalog_relation is not none and catalog_relation.catalog_type == 'BUILT_IN' -%}
             {{ return("table") }}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -173,6 +173,52 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 
 
 {# ============================================================================
+   SECTION 3B: MERGE OVERRIDE (Wrap staging source to cast unsupported types)
+   ============================================================================ #}
+
+{% macro snowflake__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) %}
+{%- set is_iceberg = (
+    config.get('catalog_name') is not none
+    or config.get('table_format', '') | lower == 'iceberg'
+) -%}
+
+{%- if is_iceberg and execute -%}
+    {#-- Describe the staging relation to find columns needing casts --#}
+    {%- set describe_sql = "DESCRIBE TABLE " ~ source -%}
+    {%- set results = run_query(describe_sql) -%}
+
+    {%- set has_unsupported = [] -%}
+    {%- set wrapped_cols = [] -%}
+
+    {%- for row in results.rows -%}
+        {%- set col_name = row['name'] -%}
+        {%- set col_type = row['type'] | string | upper -%}
+
+        {%- if 'ARRAY' in col_type or 'OBJECT' in col_type or 'VARIANT' in col_type -%}
+            {%- do has_unsupported.append(col_name) -%}
+            {%- do wrapped_cols.append('CAST(TO_JSON("' ~ col_name ~ '") AS VARCHAR(16777216)) AS "' ~ col_name ~ '"') -%}
+        {%- else -%}
+            {%- do wrapped_cols.append('"' ~ col_name ~ '"') -%}
+        {%- endif -%}
+    {%- endfor -%}
+
+    {%- if has_unsupported | length > 0 -%}
+        {#-- Create a temp view wrapping the staging relation with proper casts --#}
+        {%- set safe_source = source.incorporate(path={"identifier": source.identifier ~ "__safe"}) -%}
+        {%- set create_safe_sql = "CREATE OR REPLACE TEMPORARY VIEW " ~ safe_source ~ " AS SELECT " ~ wrapped_cols | join(", ") ~ " FROM " ~ source -%}
+        {%- do run_query(create_safe_sql) -%}
+
+        {{ return(dbt.get_merge_sql(target, safe_source, unique_key, dest_columns, incremental_predicates)) }}
+    {%- else -%}
+        {{ return(dbt.get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) }}
+    {%- endif -%}
+{%- else -%}
+    {{ return(dbt.get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) }}
+{%- endif -%}
+{% endmacro %}
+
+
+{# ============================================================================
    SECTION 4: CONTRACT MISMATCH BYPASS (Silence Python validation)
    ============================================================================ #}
 

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -11,27 +11,27 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
    ============================================================================ #}
 
 {% macro get_table_columns_and_constraints() %}
-{{ return('') }}
+            {{ return('') }}
 {% endmacro %}
 
 {% macro default__get_table_columns_and_constraints() %}
-{{ return('') }}
+            {{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__get_table_columns_and_constraints() %}
-{{ return('') }}
+            {{ return('') }}
 {% endmacro %}
 
 {% macro render_raw_columns_constraints(raw_columns) %}
-{{ return('') }}
+            {{ return('') }}
 {% endmacro %}
 
 {% macro default__render_raw_columns_constraints(raw_columns) %}
-{{ return('') }}
+            {{ return('') }}
 {% endmacro %}
 
 {% macro snowflake__render_raw_columns_constraints(raw_columns) %}
-{{ return('') }}
+            {{ return('') }}
 {% endmacro %}
 
 

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -106,8 +106,13 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 {%- endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}
-{% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
-{{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
+{%- set is_iceberg = (config.get('catalog_name') is not none or config.get('table_format', '') | lower == 'iceberg') -%}
+{% if is_iceberg %}
+  {% set safe_sql = cp_dbt_standard_package.iceberg_type_safe_wrap(sql) %}
+  {{ return(dbt.snowflake__create_view_as(relation, safe_sql)) }}
+{% else %}
+  {{ return(dbt.snowflake__create_view_as(relation, sql)) }}
+{% endif %}
 {%- endmacro %}
 
 {% macro snowflake__get_create_view_as_sql(relation, sql) -%}

--- a/macros/iceberg_overrides.sql
+++ b/macros/iceberg_overrides.sql
@@ -219,6 +219,28 @@ PURPOSE:    Globally intercepts dbt's native Snowflake materialization macros to
 
 
 {# ============================================================================
+   SECTION 3C: ALTER COLUMN TYPE BYPASS (Prevent Iceberg type alteration)
+   ============================================================================ #}
+
+{% macro snowflake__alter_column_type(relation, column_name, new_column_type) %}
+{%- set is_iceberg = (
+    config.get('catalog_name') is not none
+    or config.get('table_format', '') | lower == 'iceberg'
+) -%}
+{%- set upper_type = new_column_type | upper -%}
+{%- set is_unsupported_type = ('VARIANT' in upper_type or 'ARRAY' in upper_type or 'OBJECT' in upper_type) -%}
+{%- if is_iceberg and is_unsupported_type -%}
+    {#-- Skip ALTER only for Iceberg-unsupported types (VARIANT/ARRAY/OBJECT).
+         These are phantom mismatches from the staging view's native types;
+         the actual casting is handled at MERGE time by the get_merge_sql override. --#}
+    {{ log("Iceberg: skipping ALTER COLUMN TYPE for " ~ column_name ~ " to " ~ new_column_type ~ " (unsupported Iceberg type)", info=True) }}
+{%- else -%}
+    {{ return(dbt.snowflake__alter_column_type(relation, column_name, new_column_type)) }}
+{%- endif -%}
+{% endmacro %}
+
+
+{# ============================================================================
    SECTION 4: CONTRACT MISMATCH BYPASS (Silence Python validation)
    ============================================================================ #}
 

--- a/macros/iceberg_overrides_docs.md
+++ b/macros/iceberg_overrides_docs.md
@@ -4,7 +4,12 @@
 
 `iceberg_overrides.sql` is a Jinja macro file in `cp-dbt-standard-package` that globally intercepts dbt's native Snowflake materialization macros. Its primary purpose is to make all model output **safe for Snowflake Native Iceberg tables** by dynamically inspecting and recasting column types that Iceberg does not support or that require explicit precision.
 
-It is organized into five sections, each addressing a distinct compatibility concern.
+- Semi-structured types (`VARIANT`, `ARRAY`, `OBJECT`)
+- Timestamp / numeric type normalization
+- Avoiding invalid `ALTER TABLE` DDL on Iceberg tables
+- Incremental strategies (merge) when above datatypes are encountered
+
+It is organized into five sections, each addressing a distinct compatibility concern. These macros are meant to be used with **dbt Core ≥ 1.11**.
 
 ---
 
@@ -37,12 +42,16 @@ Non-Iceberg models fall through to the original dbt logic unchanged.
 These macros intercept every DDL path dbt uses to materialize a model. The pattern for table materializations is:
 
 1. Run `iceberg_type_safe_wrap(compiled_code)` to get a cast-safe SELECT.
-2. Execute `CREATE OR REPLACE TEMPORARY TABLE <relation>__dbt_pre AS <safe_sql>` — a regular (non-Iceberg) temp table that accepts all types.
-3. Pass `SELECT * FROM <relation>__dbt_pre` as the body of the real `CREATE ICEBERG TABLE` DDL.
+2. Pass that safe SQL directly into dbt's native table/view creation macros as the body of the real `CREATE ICEBERG <TABLE>` DDL.
 
-This two-step approach ensures type coercions happen in a permissive staging table before being read into the strict Iceberg target.
+This two-step approach ensures type coercions happen in a different SQL before being read into the strict Iceberg target.
 
-**`snowflake__create_table_as` skips this two-step path when `temporary=True`** — temporary relations are staging helpers for incremental models and do not need Iceberg type casting.
+### Section 3B & 3C — Incremental Merge & Alter Bypass
+Macros: snowflake__get_merge_sql, snowflake__alter_column_type
+
+MERGE Override: For incremental Iceberg models, the staging relation might natively hold unsupported types. This macro intercepts the MERGE operation, dynamically introspects the staging table, and wraps it in a temporary safe view (__safe) that casts VARIANT, ARRAY, and OBJECT to JSON strings before merging into the final target.
+
+ALTER Bypass: Prevents dbt from attempting to ALTER COLUMN TYPE on Iceberg tables for phantom mismatches (like native arrays vs. stringified JSON arrays), skipping the command to prevent errors.
 
 ---
 
@@ -155,3 +164,4 @@ A short-lived `TEMPORARY TABLE` created in the same session as the dbt run, name
 | dbt YAML contract DDL injection | `CREATE ICEBERG TABLE` fails with inline constraint syntax | Override `get_table_columns_and_constraints` to return empty string |
 | dbt Python contract column assertion | Build failure due to type name mismatch after casting | Override `get_assert_columns_equivalent` to return empty string |
 | Iceberg incremental models using view as temp relation | Merge/delete+insert fails — can't merge from a view into Iceberg | Force `tmp_relation_type = "table"` for Iceberg models |
+| Phantom type mismatches during incremental runs	| dbt attempts ALTER COLUMN TYPE and fails | Override snowflake__alter_column_type to skip on JSON types |


### PR DESCRIPTION
https://cp9.atlassian.net/jira/software/c/projects/DPB/boards/440?selectedIssue=DPB-2503

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dbt-Snowflake materialization, merge, and schema-sync paths for all Iceberg models; mis-gating or incomplete casts could break builds or leave wrong column types on incremental loads.
> 
> **Overview**
> **Simplifies Iceberg materialization** by removing the intermediate `__dbt_pre` temporary table and feeding `iceberg_type_safe_wrap` SQL straight into Snowflake’s native `CREATE TABLE` / `CREATE ICEBERG TABLE` paths. **`snowflake__create_table_as`** and **`snowflake__create_view_as`** now apply the wrap only when the model is Iceberg (`catalog_name` or `table_format: iceberg`), not for every non-temporary build.
> 
> **Adds incremental fixes for semi-structured columns** (`VARIANT`, `ARRAY`, `OBJECT`): **`snowflake__get_merge_sql`** describes the staging relation at execute time and, when needed, builds a `__safe` temp view that stringifies those types with `TO_JSON` before delegating to dbt’s merge SQL. **`snowflake__alter_column_type`** no-ops on Iceberg when dbt tries to alter to those types—addressing phantom mismatches from **`sync_all_columns`** while real coercion happens at merge time.
> 
> Docs in **`iceberg_overrides_docs.md`** are updated for the direct safe-SQL flow and the new merge/alter sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ed0739b04dae8645b4998bbc164a6b7bbd8c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->