### PR TITLE
DPB-2546: Refactor V1 set_query_tag to read V2 dim, cap-at-LARGE

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,12 +1,12 @@
 {% macro set_query_tag(extra = {}) -%}
-  
+
   {% set airflow_run = env_var('AIRFLOW_RUN', 'true') %}
-  
+
   {# 1. Global Tagging (Executes for Everyone) #}
   {% set merged_extra = extra.copy() %}
   {% do merged_extra.update({
-      'invocation_id': invocation_id, 
-      'model': model.name, 
+      'invocation_id': invocation_id,
+      'model': model.name,
       'is_airflow_run': airflow_run
   }) %}
   {% set result = adapter.dispatch('set_query_tag', 'dbt_query_tags')(extra=merged_extra) %}
@@ -14,45 +14,61 @@
 
   {# 2. Dynamic Warehouse Logic (Conditional Feature Toggle) #}
   {% if var('enable_dynamic_warehouse', false) %}
-      
-      {# Temporarily scale down to XSMALL just for the lookup query to save costs #}
-      {% do run_query('use warehouse CP_DBT_XSMALL_WH') %}
 
-      {# Fetch SF_DATABASE and uppercase it for safe substring matching #}
-      {% set sf_database = env_var('SF_DATABASE', '').upper() %}
-      
-      {# Safely determine the database using substring matching #}
-      {% if 'DEV_' in sf_database %}
-          {% set db = 'DEV_SF_ANALYTICS_HUB' %}
-      {% elif 'PROD_' in sf_database %}
-          {% set db = 'PROD_SF_ANALYTICS_HUB' %}
-      {% else %}
-          {# Fail fast if the environment prefix is unknown #}
-          {% do exceptions.raise_compiler_error("Cannot determine environment from SF_DATABASE. Must contain 'DEV' or 'PROD'. Got database name: " ~ sf_database) %}
+      {% set default_warehouse = var('warehouse_recommendation_default', 'CP_DBT_LARGE_WH') %}
+      {% set lookup_warehouse = var('warehouse_recommendation_lookup', 'CP_DBT_XSMALL_WH') %}
+
+      {# Scale down to lookup warehouse for the dim read #}
+      {% do run_query('use warehouse ' ~ lookup_warehouse) %}
+
+      {% set relation = api.Relation.create(
+          database='OPS_CUR',
+          schema='WH_RECOMMENDATIONS',
+          identifier='DIM_WAREHOUSE_RECOMMENDATION'
+      ) %}
+
+      {% set rec_query %}
+          select
+              override_warehouse_name,
+              override_warehouse_size,
+              recommended_warehouse_size
+          from {{ relation }}
+          where source_uri = '{{ model.name }}'
+              and airflow = '{{ airflow_run }}'
+          limit 1
+      {% endset %}
+
+      {% set selected_wh = default_warehouse %}
+      {% if execute %}
+          {% set results = run_query(rec_query) %}
+          {% if results and results.rows | length > 0 %}
+              {% set row = results.rows[0] %}
+              {% if row[0] %}
+                  {% set selected_wh = row[0] %}
+              {% elif row[1] %}
+                  {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[1]) ~ '_WH' %}
+              {% elif row[2] %}
+                  {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[2]) ~ '_WH' %}
+              {% endif %}
+          {% endif %}
       {% endif %}
-      
-      {# Create the relation for the recommendation table #}
-      {% set rec_table = api.Relation.create(
-          database=db, 
-          schema='WH_RECOMMENDATION_ANALYSIS', 
-          identifier='WEEK_SOURCE_SIZING_RECOMMENDATIONS_TBL'
-      ) %}
 
-      {# Lookup the recommended warehouse #}
-      {% set where_stmt = "source_uri = '" ~ model.name ~ "' and airflow = '" ~ airflow_run ~ "'" %}
-      
-      {# Note: We use dbt_utils to fetch the value #}
-      {% set wh_list = dbt_utils.get_column_values(
-          table=rec_table, 
-          column='RECOMMENDED_WAREHOUSE_NAME', 
-          default=['CP_DBT_LARGE_WH'], 
-          where=where_stmt
-      ) %}
-      
-      {# Route the model to the recommended warehouse #}
-      {% set selected_wh = wh_list[0] if wh_list else 'CP_DBT_LARGE_WH' %}
       {% do run_query("USE WAREHOUSE " ~ selected_wh.upper()) %}
-      
+
   {% endif %}
 
+{%- endmacro %}
+
+
+{#
+  Translate a generation-agnostic size token from
+  OPS_CUR.WH_RECOMMENDATIONS.DIM_WAREHOUSE_RECOMMENDATION into the V1 named-pool
+  size segment. Caps anything above LARGE at LARGE because V1 deploy roles do
+  not have USAGE on CP_DBT_{X,2X,...}LARGE_WH. Strips hyphens so '2x-large'
+  becomes '2XLARGE' (used only when the cap is relaxed; today the cap holds).
+#}
+{% macro v1_size_to_name(size_token) -%}
+    {%- set cap_above_large = ['x-large', '2x-large', '3x-large', '4x-large', '5x-large', '6x-large'] -%}
+    {%- set effective = 'large' if size_token in cap_above_large else size_token -%}
+    {{- effective.replace('-', '') -}}
 {%- endmacro %}

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -30,7 +30,6 @@
       {% set rec_query %}
           select
               override_warehouse_name,
-              override_warehouse_size,
               recommended_warehouse_size
           from {{ relation }}
           where source_uri = '{{ model.name }}'
@@ -47,8 +46,6 @@
                   {% set selected_wh = row[0] %}
               {% elif row[1] %}
                   {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[1]) ~ '_WH' %}
-              {% elif row[2] %}
-                  {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[2]) ~ '_WH' %}
               {% endif %}
           {% endif %}
       {% endif %}


### PR DESCRIPTION
## Summary

Repoints the `Brooklyn-package-2-8` `set_query_tag.sql` from the legacy V1 dim (`WH_RECOMMENDATION_ANALYSIS.WEEK_SOURCE_SIZING_RECOMMENDATIONS_TBL`) to the V2 dim (`OPS_CUR.WH_RECOMMENDATIONS.DIM_WAREHOUSE_RECOMMENDATION`). Both V1 and V2 consumers now resolve off the same source of truth.

**Companion PR (must merge first):**
[`colpal/analytics-ops#590`](https://github.com/colpal/analytics-ops/pull/590) — adds `override_warehouse_name` as a separate column on the dim so this macro can route bespoke overrides (e.g. `FIN_ELT_ACDOCA_2XL_WH`) verbatim and fall back to size-token-based V1 name composition for the algorithmic case.

> Earlier attempts were closed in favor of the cleaner cut: `analytics-ops#588` was based on stale master and edited a deleted folder; `analytics-ops#589` was pre-#586 master and still removed the join-key + identity-column work that #586 has since codified. The companion `cp-dbt-standard-package#65` (V2 macro) was closed because the upstream `release/v2` macro already resolves correctly against the unchanged `recommended_warehouse_name` column, so no V2 macro change is required.

## Diff

```jinja
{% if var('enable_dynamic_warehouse', false) %}
    {% set default_warehouse = var('warehouse_recommendation_default', 'CP_DBT_LARGE_WH') %}
    {% set lookup_warehouse = var('warehouse_recommendation_lookup', 'CP_DBT_XSMALL_WH') %}
    {% do run_query('use warehouse ' ~ lookup_warehouse) %}

    {% set relation = api.Relation.create(
        database='OPS_CUR', schema='WH_RECOMMENDATIONS',
        identifier='DIM_WAREHOUSE_RECOMMENDATION'
    ) %}

    {% set rec_query %}
        select override_warehouse_name, recommended_warehouse_size
        from {{ relation }}
        where source_uri = '{{ model.name }}' and airflow = '{{ airflow_run }}'
        limit 1
    {% endset %}

    {% set selected_wh = default_warehouse %}
    {% if execute %}
        {% set results = run_query(rec_query) %}
        {% if results and results.rows | length > 0 %}
            {% set row = results.rows[0] %}
            {% if row[0] %}
                {% set selected_wh = row[0] %}
            {% elif row[1] %}
                {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[1]) ~ '_WH' %}
            {% endif %}
        {% endif %}
    {% endif %}

    {% do run_query("USE WAREHOUSE " ~ selected_wh.upper()) %}
{% endif %}

{% macro v1_size_to_name(size_token) -%}
    {%- set cap = ['x-large','2x-large','3x-large','4x-large','5x-large','6x-large'] -%}
    {%- set s = 'large' if size_token in cap else size_token -%}
    {{- s.replace('-', '') -}}
{%- endmacro %}
```

Key changes vs the current Brooklyn macro:

- Drops the `SF_DATABASE` env discovery and DEV/PROD branching entirely (V2 dim is account-global).
- Drops the legacy V1 dim relation.
- Reads two columns from `OPS_CUR.WH_RECOMMENDATIONS.DIM_WAREHOUSE_RECOMMENDATION` (`override_warehouse_name` is added by companion PR #590).
- Composes `'CP_DBT_' ~ <size> ~ '_WH'` (V1 named pool) via the new `v1_size_to_name` helper, capped at `LARGE`.
- The `enable_dynamic_warehouse` gate stays so the dbt-common shim continues to no-op for repos not on the allowlist.
- Lookup/default warehouses exposed as dbt vars (`warehouse_recommendation_lookup`, `warehouse_recommendation_default`).
- `unset_query_tag.sql` is **unchanged**.

## Cap-at-LARGE policy

V1 deploy roles have USAGE only on `CP_DBT_{XSMALL,SMALL,MEDIUM,LARGE}_WH`. Algorithmic recommendations above LARGE map to `LARGE` so the V1 macro never emits a `USE WAREHOUSE` for a warehouse the executing role can't access. Larger sizing remains available through the bespoke `override_warehouse_name` path in the override seed (e.g. `FIN_ELT_ACDOCA_4XL_WH`).

## Idempotency

Applying this change twice produces the same state — the macro reads the dim deterministically and the `USE WAREHOUSE` resolution is a pure function of `(source_uri, airflow)` plus configured defaults.

## Test plan

- [ ] Companion analytics-ops PR #590 merges first (provides `override_warehouse_name`)
- [ ] Canary `cp-aat-fin-data-engineering` (or another active Brooklyn-pinned V1 repo) on this PR's commit SHA
- [ ] Run `dbt build` in dev; inspect `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY.WAREHOUSE_NAME`
- [ ] Assert all resolved warehouses are in V1 pool (`CP_DBT_*_WH`) or bespoke (`FIN_ELT_*`, `CP_DBT_*_WH_C2C_*`)