### PR TITLE
Update set_query_tag.sql

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,12 +1,12 @@
 {% macro set_query_tag(extra = {}) -%}
-  
+
   {% set airflow_run = env_var('AIRFLOW_RUN', 'true') %}
-  
+
   {# 1. Global Tagging (Executes for Everyone) #}
   {% set merged_extra = extra.copy() %}
   {% do merged_extra.update({
-      'invocation_id': invocation_id, 
-      'model': model.name, 
+      'invocation_id': invocation_id,
+      'model': model.name,
       'is_airflow_run': airflow_run
   }) %}
   {% set result = adapter.dispatch('set_query_tag', 'dbt_query_tags')(extra=merged_extra) %}
@@ -14,45 +14,62 @@
 
   {# 2. Dynamic Warehouse Logic (Conditional Feature Toggle) #}
   {% if var('enable_dynamic_warehouse', false) %}
-      
-      {# Temporarily scale down to XSMALL just for the lookup query to save costs #}
-      {% do run_query('use warehouse CP_DBT_XSMALL_WH') %}
 
-      {# Fetch SF_DATABASE and uppercase it for safe substring matching #}
-      {% set sf_database = env_var('SF_DATABASE', '').upper() %}
-      
-      {# Safely determine the database using substring matching #}
-      {% if 'DEV_' in sf_database %}
-          {% set db = 'DEV_SF_ANALYTICS_HUB' %}
-      {% elif 'PROD_' in sf_database %}
-          {% set db = 'PROD_SF_ANALYTICS_HUB' %}
-      {% else %}
-          {# Fail fast if the environment prefix is unknown #}
-          {% do exceptions.raise_compiler_error("Cannot determine environment from SF_DATABASE. Must contain 'DEV' or 'PROD'. Got database name: " ~ sf_database) %}
+      {% set default_warehouse = var('warehouse_recommendation_default', 'CP_DBT_LARGE_WH') %}
+      {% set lookup_warehouse = var('warehouse_recommendation_lookup', 'CP_DBT_XSMALL_WH') %}
+
+      {# Scale down to lookup warehouse for the dim read #}
+      {% do run_query('use warehouse ' ~ lookup_warehouse) %}
+
+      {% set relation = api.Relation.create(
+          database='OPS_CUR',
+          schema='WH_RECOMMENDATIONS',
+          identifier='DIM_WAREHOUSE_RECOMMENDATION'
+      ) %}
+
+      {% set rec_query %}
+          select
+              override_warehouse_name,
+              recommended_warehouse_size
+          from {{ relation }}
+          where source_uri = '{{ model.name }}'
+              and airflow = '{{ airflow_run }}'
+          limit 1
+      {% endset %}
+
+      {% set selected_wh = default_warehouse %}
+      {% if execute %}
+          {% set results = run_query(rec_query) %}
+          {% if results and results.rows | length > 0 %}
+              {% set row = results.rows[0] %}
+              
+              {# Evaluates Name Override (row[0]) first, falls back to Recommended Size (row[1]) #}
+              {% if row[0] %}
+                  {% set selected_wh = row[0] %}
+              {% elif row[1] %}
+                  {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[1]) ~ '_WH' %}
+              {% endif %}
+          {% endif %}
       {% endif %}
-      
-      {# Create the relation for the recommendation table #}
-      {% set rec_table = api.Relation.create(
-          database=db, 
-          schema='WH_RECOMMENDATION_ANALYSIS', 
-          identifier='WEEK_SOURCE_SIZING_RECOMMENDATIONS_TBL'
-      ) %}
 
-      {# Lookup the recommended warehouse #}
-      {% set where_stmt = "source_uri = '" ~ model.name ~ "' and airflow = '" ~ airflow_run ~ "'" %}
-      
-      {# Note: We use dbt_utils to fetch the value #}
-      {% set wh_list = dbt_utils.get_column_values(
-          table=rec_table, 
-          column='RECOMMENDED_WAREHOUSE_NAME', 
-          default=['CP_DBT_LARGE_WH'], 
-          where=where_stmt
-      ) %}
-      
-      {# Route the model to the recommended warehouse #}
-      {% set selected_wh = wh_list[0] if wh_list else 'CP_DBT_LARGE_WH' %}
       {% do run_query("USE WAREHOUSE " ~ selected_wh.upper()) %}
-      
+
   {% endif %}
 
+{%- endmacro %}
+
+
+{#
+  Translate a generation-agnostic size token from
+  OPS_CUR.WH_RECOMMENDATIONS.DIM_WAREHOUSE_RECOMMENDATION into the V1 named-pool
+  size segment. Caps anything above LARGE at LARGE because V1 deploy roles do
+  not have USAGE on CP_DBT_{X,2X,...}LARGE_WH. Strips hyphens so '2x-large'
+  becomes '2XLARGE' (used only when the cap is relaxed; today the cap holds).
+#}
+{% macro v1_size_to_name(size_token) -%}
+    {# Case-sensitivity fix applied here using | lower #}
+    {%- set token_lower = size_token | lower -%}
+    {%- set cap_above_large = ['x-large', '2x-large', '3x-large', '4x-large', '5x-large', '6x-large'] -%}
+    {%- set effective = 'large' if token_lower in cap_above_large else token_lower -%}
+    {{- effective.replace('-', '') | upper -}}
 {%- endmacro %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes runtime Snowflake warehouse routing for all models when the feature flag is enabled, which can affect cost, performance, and role USAGE if lookups or mappings are wrong.
> 
> **Overview**
> When **`enable_dynamic_warehouse`** is on, **`set_query_tag`** no longer infers DEV/PROD from **`SF_DATABASE`** or reads **`WEEK_SOURCE_SIZING_RECOMMENDATIONS_TBL`** via **`dbt_utils.get_column_values`**. It now uses configurable **`warehouse_recommendation_lookup`** / **`warehouse_recommendation_default`** vars, runs a **`run_query`** lookup against **`OPS_CUR.WH_RECOMMENDATIONS.DIM_WAREHOUSE_RECOMMENDATION`**, and picks a warehouse from **`override_warehouse_name`** or builds **`CP_DBT_{size}_WH`** from **`recommended_warehouse_size`**.
> 
> A new **`v1_size_to_name`** macro normalizes size tokens (case-insensitive, hyphen-stripped) and **caps sizes above LARGE to LARGE** for V1 pool USAGE limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1711c4841b5b60265cdf92e38269ca68f6b4f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->