### PR TITLE
Set airflow run variable to true for testing purpose

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,6 +1,6 @@
 {% macro set_query_tag(extra = {}) -%}
 
-  {% set airflow_run = env_var('AIRFLOW_RUN', 'true') %}
+  {% set airflow_run = 'true' %}
 
   {# 1. Global Tagging (Executes for Everyone) #}
   {% set merged_extra = extra.copy() %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Forces Airflow-specific query tags and warehouse recommendation filtering on all invocations; if merged beyond a test branch, non-Airflow runs could pick the wrong warehouse or report incorrect metadata.
> 
> **Overview**
> **Hardcodes `airflow_run` to `'true'`** in the `set_query_tag` macro instead of reading the `AIRFLOW_RUN` environment variable (defaulting to `'true'` when unset).
> 
> That value is passed into query tags as `is_airflow_run` and, when dynamic warehouse selection is enabled, is used in the `DIM_WAREHOUSE_RECOMMENDATION` lookup (`airflow = '{{ airflow_run }}'`). Every run will behave as an Airflow run for tagging and warehouse routing, regardless of how the job was invoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa4c3b990a178b1fccaef5e95557ad134555ad47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->