### PR TITLE
Resolve the macro error

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -47,7 +47,15 @@
               {% if row[0] %}
                   {% set selected_wh = row[0] %}
               {% elif row[1] %}
-                  {% set selected_wh = 'CP_DBT_' ~ v1_size_to_name(row[1]) ~ '_WH' %}
+                  
+                  {# Inline Size Transformation Logic #}
+                  {% set token_lower = row[1] | lower %}
+                  {% set cap_above_large = ['x-large', '2x-large', '3x-large', '4x-large', '5x-large', '6x-large'] %}
+                  {% set effective_size = 'large' if token_lower in cap_above_large else token_lower %}
+                  {% set formatted_size = effective_size.replace('-', '') | upper %}
+                  
+                  {% set selected_wh = 'CP_DBT_' ~ formatted_size ~ '_WH' %}
+                  
               {% endif %}
           {% endif %}
       {% endif %}
@@ -56,20 +64,4 @@
 
   {% endif %}
 
-{%- endmacro %}
-
-
-{#
-  Translate a generation-agnostic size token from
-  OPS_CUR.WH_RECOMMENDATIONS.DIM_WAREHOUSE_RECOMMENDATION into the V1 named-pool
-  size segment. Caps anything above LARGE at LARGE because V1 deploy roles do
-  not have USAGE on CP_DBT_{X,2X,...}LARGE_WH. Strips hyphens so '2x-large'
-  becomes '2XLARGE' (used only when the cap is relaxed; today the cap holds).
-#}
-{% macro v1_size_to_name(size_token) -%}
-    {# Case-sensitivity fix applied here using | lower #}
-    {%- set token_lower = size_token | lower -%}
-    {%- set cap_above_large = ['x-large', '2x-large', '3x-large', '4x-large', '5x-large', '6x-large'] -%}
-    {%- set effective = 'large' if token_lower in cap_above_large else token_lower -%}
-    {{- effective.replace('-', '') | upper -}}
 {%- endmacro %}


### PR DESCRIPTION
Refactor size transformation logic for warehouse selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor in dynamic warehouse selection with equivalent mapping logic; no new auth or data paths.
> 
> **Overview**
> Fixes a macro error by **removing** the separate `v1_size_to_name` helper and **inlining** the same size-to-warehouse-name rules inside `set_query_tag` when a recommendation row has no override name.
> 
> Behavior for the recommended-size path is unchanged: normalize the token to lowercase, cap `x-large` through `6x-large` to `large` for V1 pool limits, strip hyphens, uppercase, and build `CP_DBT_{SIZE}_WH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8177866ddc9c448a3ecdddf20d431ef890d2744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->