### PR TITLE
Update airflow_run to use environment variable

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,6 +1,6 @@
 {% macro set_query_tag(extra = {}) -%}
 
-  {% set airflow_run = 'true' %}
+  {% set airflow_run = env_var('AIRFLOW_RUN', 'true') %}
 
   {# 1. Global Tagging (Executes for Everyone) #}
   {% set merged_extra = extra.copy() %}


### PR DESCRIPTION
Change the default value of 'airflow_run' to be set from an environment variable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line default-preserving change to observability/warehouse selection metadata; no auth or data-path changes.
> 
> **Overview**
> The `set_query_tag` macro no longer hardcodes **`airflow_run`** to `'true'`. It now uses **`env_var('AIRFLOW_RUN', 'true')`**, so runs outside Airflow can override the flag while keeping today’s behavior when the variable is unset.
> 
> That value still drives **`is_airflow_run`** in merged query tags and the **`airflow`** filter in the dynamic warehouse recommendation lookup against `DIM_WAREHOUSE_RECOMMENDATION`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab25e6d5fe3aac12472aedf532b613870b24c700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->