### PR TITLE
Brooklyn package 2 8

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -7,6 +7,7 @@
   {% do merged_extra.update({
       'invocation_id': invocation_id,
       'model': model.name,
+      'database': model.database,
       'is_airflow_run': airflow_run
   }) %}
   {% set result = adapter.dispatch('set_query_tag', 'dbt_query_tags')(extra=merged_extra) %}
@@ -33,6 +34,7 @@
               recommended_warehouse_size
           from {{ relation }}
           where source_uri = '{{ model.name }}'
+              and database_name = '{{ model.database }}'
               and airflow = '{{ airflow_run }}'
           limit 1
       {% endset %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes runtime warehouse selection when `enable_dynamic_warehouse` is on; incorrect matching could pick the wrong warehouse (cost/performance) but the change is narrowly scoped to one macro.
> 
> **Overview**
> When **dynamic warehouse** is enabled, warehouse lookups against `DIM_WAREHOUSE_RECOMMENDATION` now filter on **`database_name`** in addition to `source_uri` and `airflow`, so the same model name in different databases can resolve to different warehouses.
> 
> **Query tags** also include **`database`** (`model.database`) alongside `model`, `invocation_id`, and `is_airflow_run` for clearer Snowflake attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec938e9d4177a5bda67fc15e8c9186440dd0b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->