### PR TITLE
Dpb 2546/wh recom

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -7,6 +7,7 @@
   {% do merged_extra.update({
       'invocation_id': invocation_id,
       'model': model.name,
+      'database': model.database,
       'is_airflow_run': airflow_run
   }) %}
   {% set result = adapter.dispatch('set_query_tag', 'dbt_query_tags')(extra=merged_extra) %}
@@ -33,6 +34,7 @@
               recommended_warehouse_size
           from {{ relation }}
           where source_uri = '{{ model.name }}'
+              and database_name = '{{ model.database }}'
               and airflow = '{{ airflow_run }}'
           limit 1
       {% endset %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which Snowflake warehouse is selected for dbt runs when dynamic warehouse is on; mis-keyed dim data could cause wrong warehouse or unintended default fallback.
> 
> **Overview**
> When **dynamic warehouse** is enabled, warehouse lookup against `DIM_WAREHOUSE_RECOMMENDATION` now filters on **`model.database`** in addition to model name and Airflow run, so recommendations are keyed per database instead of model name alone.
> 
> **Query tags** also include **`database`** in the metadata sent through `dbt_query_tags`, alongside the existing model and invocation fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30849ba131992b0c8ca55b296b0cdd51ff94d038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->