### PR TITLE
DPB-2581-Refactor SQL query to use case-insensitive comparisons fo v1

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -28,14 +28,17 @@
           identifier='DIM_WAREHOUSE_RECOMMENDATION'
       ) %}
 
+      {% set active_db = model.database | string | upper %}
+      {% set search_db = active_db[:-3] if active_db.endswith('_PD') else active_db %}
+
       {% set rec_query %}
           select
               override_warehouse_name,
               recommended_warehouse_size
           from {{ relation }}
-          where source_uri = '{{ model.name }}'
-              and database_name = '{{ model.database }}'
-              and airflow = '{{ airflow_run }}'
+          where upper(source_uri) = upper('{{ model.name }}')
+              and upper(database_name) = upper('{{ search_db }}')
+              and lower(airflow) = lower('{{ airflow_run }}')
           limit 1
       {% endset %}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> When dynamic warehouse selection is enabled, a failed or incorrect dim match falls back to the default warehouse, which can affect run cost and performance but does not touch auth or data correctness.
> 
> **Overview**
> Updates the **dynamic warehouse** lookup in `set_query_tag` so recommendation rows match more reliably against `DIM_WAREHOUSE_RECOMMENDATION`.
> 
> **`source_uri`**, **`database_name`**, and **`airflow`** are compared case-insensitively (`upper`/`lower`) instead of exact string equality. For **`database_name`**, the macro now derives **`search_db`** from the model database: if it ends with **`_PD`**, that suffix is stripped before the lookup, so PD-target runs can still hit recommendations keyed on the base database name.
> 
> Behavior only applies when **`enable_dynamic_warehouse`** is on; tagging logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3e60d7f0a91012d79d2c9dcc901ceb29acfd86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->