### PR TITLE
Dpb 2546/wh recom

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -28,14 +28,17 @@
           identifier='DIM_WAREHOUSE_RECOMMENDATION'
       ) %}
 
+      {% set active_db = model.database | string | upper %}
+      {% set search_db = active_db[:-3] if active_db.endswith('_PD') else active_db %}
+
       {% set rec_query %}
           select
               override_warehouse_name,
               recommended_warehouse_size
           from {{ relation }}
-          where source_uri = '{{ model.name }}'
-              and database_name = '{{ model.database }}'
-              and airflow = '{{ airflow_run }}'
+          where upper(source_uri) = upper('{{ model.name }}')
+              and upper(database_name) = upper('{{ search_db }}')
+              and lower(airflow) = lower('{{ airflow_run }}')
           limit 1
       {% endset %}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped change to optional dynamic warehouse lookup matching; no auth or data-path changes, though a bad match could still pick the wrong warehouse size.
> 
> **Overview**
> Updates the dynamic warehouse lookup in `set_query_tag` so recommendation rows match more reliably at runtime.
> 
> When resolving `DIM_WAREHOUSE_RECOMMENDATION`, the macro now derives **`search_db`** from the active model database by stripping a trailing **`_PD`** suffix before filtering on `database_name`, so PD-targeted models can still hit recommendations keyed on the base database name.
> 
> The dim query filters also use **case-insensitive** matching: `upper()` on `source_uri` and `database_name`, and `lower()` on `airflow`, instead of exact string equality on those fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2815da6d8631afc57e3e9f80330063bbbcd759c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->