### PR TITLE
Dpb 2581.To remove the case sensitivity for model name and to process the _PD database

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -7,7 +7,11 @@
     ) %}
     
     {% set airflow_run = env_var('AIRFLOW_RUN', 'true') %}
-    {% set where_statement = "source_uri = '" ~ model.name ~ "' and database_name = '" ~ model.database ~ "' and airflow = '" ~ airflow_run ~ "'" %}
+
+    {% set active_db = model.database | string | upper %}
+    {% set search_db = active_db[:-3] if active_db.endswith('_PD') else active_db %}
+    
+    {% set where_statement = "upper(source_uri) = upper('" ~ model.name ~ "') and upper(database_name) = '" ~ search_db ~ "' and lower(airflow) = lower('" ~ airflow_run ~ "')" %}
 
     {% set warehouse = dbt_utils.get_column_values(
         relation, 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to dbt macro filter logic for warehouse selection; wrong matching could pick the default warehouse but does not touch auth or data transformation logic.
> 
> **Overview**
> Updates **`set_query_tag`** so warehouse recommendations from `DIM_WAREHOUSE_RECOMMENDATION` match more reliably at run time.
> 
> The lookup `where` clause now compares **`source_uri`** and **`airflow`** case-insensitively (`upper` / `lower`), and **`database_name`** is derived from the active model database in uppercase, **stripping a `_PD` suffix** when present so PD targets resolve against the same recommendation rows as the non-PD database.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727b7adb432e28b34313005e6c412737cf6a70e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->