### PR TITLE
bugfix(DPB-2513): gate on-run-end hooks by command and package

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,7 +27,20 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   +transient: false
 
-# Automatically reapply Snowflake tags after every dbt run (fixes tag loss on view recreation)
+# Reapply Snowflake tags + reconcile CERTIFIED_READ grants after object-mutating dbt runs.
+#
+# DPB-2513: Gate on flags.WHICH so hooks fire ONLY for commands that create or
+# replace Snowflake objects (run, build, seed, snapshot, clone).
+#
+# Skipped commands (test, compile, parse, deps, list, docs, debug, show, clean,
+# init) do not touch object DDL — tag reapplication and CERTIFIED_READ grant
+# reconciliation have nothing to reconcile. This also unblocks per-domain
+# read-only test roles (e.g. <DOMAIN>_TEST) which must not hold USAGE on
+# OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS* and would otherwise fail
+# `dbt test` with 002141 "Unknown user-defined function".
+#
+# SBX / _LAB_ guard: sandbox and lab databases are analyst-owned; skip both
+# tagging and grant reconciliation there.
 on-run-end:
-  - "{% if 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.tag_models_from_results() }}{% endif %}"
-  - "{% if 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.call_certified_read_proc() }}{% endif %}"
+  - "{% if flags.WHICH in ['run','build','seed','snapshot','clone'] and 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.tag_models_from_results() }}{% endif %}"
+  - "{% if flags.WHICH in ['run','build','seed','snapshot','clone'] and 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.call_certified_read_proc() }}{% endif %}"

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -289,11 +289,18 @@
    AUTO-TAG FROM RUN RESULTS (on-run-end)
    Called automatically by on-run-end hook to reapply tags after dbt runs.
 
-   DPB-2513 command guard: skip when the current dbt invocation cannot have
-   created or replaced Snowflake objects (test / compile / parse / deps /
-   list / docs / debug / show / clean / init). Belt-and-suspenders with the
-   yaml-level guard in dbt_project.yml — protects any downstream project
-   that wires this macro into on-run-end without the yaml guard.
+   DPB-2513 guards, in order:
+     1. Command guard: skip when the current dbt invocation cannot have
+        created or replaced Snowflake objects (test / compile / parse /
+        deps / list / docs / debug / show / clean / init). Belt-and-suspenders
+        with the yaml-level guard in dbt_project.yml — protects any downstream
+        project that wires this macro into on-run-end without the yaml guard.
+     2. Metadata-package guard: skip when the only successful models were
+        from `dbt_project_evaluator`. dbt-common CI runs that package as its
+        own dedicated `dbt build --select package:dbt_project_evaluator+`
+        step; its models never carry `snowflake_tags`, so there is nothing
+        to reapply. Extend the ignore list if new metadata-only packages
+        (e.g. elementary) are added to CI.
    ============================================================ #}
 {% macro tag_models_from_results() %}
     {% if execute %}
@@ -308,9 +315,12 @@
             {{ return('') }}
         {% endif %}
 
+        {% set ignore_packages = ['dbt_project_evaluator'] %}
         {% set successful_models = [] %}
         {% for res in results %}
-            {% if res.node.resource_type == 'model' and res.status in ['success', 'pass'] %}
+            {% if res.node.resource_type == 'model'
+              and res.status in ['success', 'pass']
+              and res.node.package_name not in ignore_packages %}
                 {% do successful_models.append(res.node.unique_id) %}
             {% endif %}
         {% endfor %}
@@ -319,7 +329,11 @@
             {{ log("Auto-tagging " ~ successful_models | length ~ " deployed model(s)", info=true) }}
             {{ cp_dbt_standard_package.tag_models_on_run_end(successful_models) }}
         {% else %}
-            {{ log("No successfully deployed models to tag.", info=true) }}
+            {{ log(
+                "[tag_models_from_results] SKIPPED | no user-project models successfully built"
+                ~ " (ignoring packages: " ~ ignore_packages | join(', ') ~ ") — nothing to tag.",
+                info=true
+            ) }}
         {% endif %}
     {% endif %}
 {% endmacro %}
@@ -329,12 +343,20 @@
    CALL CERTIFIED READ PROCEDURE (on-run-end)
    Calls the Snowflake stored procedure to apply certified read grants after dbt runs.
 
-   DPB-2513 command guard: skip when the current dbt invocation cannot have
-   created or replaced Snowflake objects (test / compile / parse / deps /
-   list / docs / debug / show / clean / init). This is the primary blocker
-   for the per-domain <DOMAIN>_TEST role rollout — the read-only test role
-   must not require USAGE on OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS.
-   Belt-and-suspenders with the yaml-level guard in dbt_project.yml.
+   DPB-2513 guards, in order:
+     1. Command guard: skip when the current dbt invocation cannot have
+        created or replaced Snowflake objects (test / compile / parse /
+        deps / list / docs / debug / show / clean / init). Primary blocker
+        for the per-domain <DOMAIN>_TEST role rollout — the read-only test
+        role must not require USAGE on
+        OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS. Belt-and-suspenders
+        with the yaml-level guard in dbt_project.yml.
+     2. Metadata-package guard: skip when the only successful models were
+        from `dbt_project_evaluator`. CI's `dbt build --select
+        package:dbt_project_evaluator+` step never touches models that
+        carry IS_CERTIFIED, so CERTIFIED_READ grants cannot have been
+        wiped — the CALL would be wasted. Extend the ignore list if new
+        metadata-only packages are added to CI.
    ============================================================ #}
 {% macro call_certified_read_proc() %}
     {% if execute %}
@@ -345,6 +367,25 @@
                 ~ "' does not create or replace Snowflake objects — CERTIFIED_READ grants"
                 ~ " cannot have been wiped by this run. Hook only fires for: "
                 ~ object_mutating_cmds | join(', '),
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
+
+        {% set ignore_packages = ['dbt_project_evaluator'] %}
+        {% set user_models = [] %}
+        {% for res in results %}
+            {% if res.node.resource_type == 'model'
+              and res.status in ['success', 'pass']
+              and res.node.package_name not in ignore_packages %}
+                {% do user_models.append(res.node.unique_id) %}
+            {% endif %}
+        {% endfor %}
+        {% if user_models | length == 0 %}
+            {{ log(
+                "[call_certified_read_proc] SKIPPED | no user-project models successfully built"
+                ~ " (ignoring packages: " ~ ignore_packages | join(', ') ~ ") — CERTIFIED_READ"
+                ~ " grants cannot have been wiped by this run.",
                 info=true
             ) }}
             {{ return('') }}

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -287,10 +287,27 @@
 
 {# ============================================================
    AUTO-TAG FROM RUN RESULTS (on-run-end)
-   Called automatically by on-run-end hook to reapply tags after dbt runs
+   Called automatically by on-run-end hook to reapply tags after dbt runs.
+
+   DPB-2513 command guard: skip when the current dbt invocation cannot have
+   created or replaced Snowflake objects (test / compile / parse / deps /
+   list / docs / debug / show / clean / init). Belt-and-suspenders with the
+   yaml-level guard in dbt_project.yml — protects any downstream project
+   that wires this macro into on-run-end without the yaml guard.
    ============================================================ #}
 {% macro tag_models_from_results() %}
     {% if execute %}
+        {% set object_mutating_cmds = ['run', 'build', 'seed', 'snapshot', 'clone'] %}
+        {% if flags.WHICH not in object_mutating_cmds %}
+            {{ log(
+                "[tag_models_from_results] SKIPPED | command '" ~ flags.WHICH
+                ~ "' does not create or replace Snowflake objects — nothing to tag."
+                ~ " Hook only fires for: " ~ object_mutating_cmds | join(', '),
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
+
         {% set successful_models = [] %}
         {% for res in results %}
             {% if res.node.resource_type == 'model' and res.status in ['success', 'pass'] %}
@@ -310,10 +327,29 @@
 
 {# ============================================================
    CALL CERTIFIED READ PROCEDURE (on-run-end)
-   Calls the Snowflake stored procedure to apply certified read grants after dbt runs
+   Calls the Snowflake stored procedure to apply certified read grants after dbt runs.
+
+   DPB-2513 command guard: skip when the current dbt invocation cannot have
+   created or replaced Snowflake objects (test / compile / parse / deps /
+   list / docs / debug / show / clean / init). This is the primary blocker
+   for the per-domain <DOMAIN>_TEST role rollout — the read-only test role
+   must not require USAGE on OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS.
+   Belt-and-suspenders with the yaml-level guard in dbt_project.yml.
    ============================================================ #}
 {% macro call_certified_read_proc() %}
     {% if execute %}
+        {% set object_mutating_cmds = ['run', 'build', 'seed', 'snapshot', 'clone'] %}
+        {% if flags.WHICH not in object_mutating_cmds %}
+            {{ log(
+                "[call_certified_read_proc] SKIPPED | command '" ~ flags.WHICH
+                ~ "' does not create or replace Snowflake objects — CERTIFIED_READ grants"
+                ~ " cannot have been wiped by this run. Hook only fires for: "
+                ~ object_mutating_cmds | join(', '),
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
+
         {{ log("Calling GRANT_CERTIFIED_READ_ACCESS procedure to apply certified read grants", info=true) }}
         {% do run_query("CALL OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS()") %}
     {% endif %}

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -351,12 +351,19 @@
         role must not require USAGE on
         OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS. Belt-and-suspenders
         with the yaml-level guard in dbt_project.yml.
-     2. Metadata-package guard: skip when the only successful models were
-        from `dbt_project_evaluator`. CI's `dbt build --select
-        package:dbt_project_evaluator+` step never touches models that
-        carry IS_CERTIFIED, so CERTIFIED_READ grants cannot have been
-        wiped — the CALL would be wasted. Extend the ignore list if new
-        metadata-only packages are added to CI.
+     2. Metadata-package guard: skip when the only successful grant-holding
+        nodes (models, seeds, snapshots) were from `dbt_project_evaluator`.
+        CI's `dbt build --select package:dbt_project_evaluator+` step never
+        touches nodes that carry IS_CERTIFIED, so CERTIFIED_READ grants
+        cannot have been wiped — the CALL would be wasted. Extend the
+        ignore list if new metadata-only packages are added to CI.
+
+        Filter covers `model`, `seed`, and `snapshot` because each
+        materializes as a Snowflake table/view that can hold an
+        IS_CERTIFIED tag and therefore CERTIFIED_READ grants. Restricting
+        the filter to `model` alone (previous form) incorrectly skipped
+        the CALL on `dbt seed` / `dbt snapshot` runs whose results
+        contain no model nodes.
    ============================================================ #}
 {% macro call_certified_read_proc() %}
     {% if execute %}
@@ -373,19 +380,22 @@
         {% endif %}
 
         {% set ignore_packages = ['dbt_project_evaluator'] %}
-        {% set user_models = [] %}
+        {% set grantable_resource_types = ('model', 'seed', 'snapshot') %}
+        {% set grantable_nodes = [] %}
         {% for res in results %}
-            {% if res.node.resource_type == 'model'
+            {% if res.node.resource_type in grantable_resource_types
               and res.status in ['success', 'pass']
               and res.node.package_name not in ignore_packages %}
-                {% do user_models.append(res.node.unique_id) %}
+                {% do grantable_nodes.append(res.node.unique_id) %}
             {% endif %}
         {% endfor %}
-        {% if user_models | length == 0 %}
+        {% if grantable_nodes | length == 0 %}
             {{ log(
-                "[call_certified_read_proc] SKIPPED | no user-project models successfully built"
-                ~ " (ignoring packages: " ~ ignore_packages | join(', ') ~ ") — CERTIFIED_READ"
-                ~ " grants cannot have been wiped by this run.",
+                "[call_certified_read_proc] SKIPPED | no user-project "
+                ~ grantable_resource_types | join(' / ')
+                ~ " successfully built (ignoring packages: "
+                ~ ignore_packages | join(', ')
+                ~ ") — CERTIFIED_READ grants cannot have been wiped by this run.",
                 info=true
             ) }}
             {{ return('') }}


### PR DESCRIPTION
## Summary

Gate the two `on-run-end` hooks (`tag_models_from_results` and `call_certified_read_proc`) with two independent, complementary guards so they only fire when there is actually something to reconcile:

1. **Command guard** — hook body only runs for dbt commands that create or replace Snowflake objects: `run`, `build`, `seed`, `snapshot`, `clone`. Non-mutating commands (`test`, `compile`, `parse`, `docs generate`, `source freshness`, `deps`, `list`, `debug`, `show`, `clean`, `init`) short-circuit with an `info` log.

2. **Metadata-package guard** — even for mutating commands, if the resulting `results` list contains no successfully-built models from a user project (i.e. from a package other than `dbt_project_evaluator`), both macros skip. dbt-common CI runs `dbt build --select package:dbt_project_evaluator+ dbt_project_evaluator_exceptions` as its own dedicated step; the evaluator's models never carry `snowflake_tags` and are never `IS_CERTIFIED`, so the CALL is pure waste. Ignore-list is a macro-local list so new metadata-only packages (e.g. `elementary`) can be appended.

## Why

Ticket: [DPB-2513](https://cp9.atlassian.net/browse/DPB-2513) — introduces a per-domain read-only `<DOMAIN>_TEST` role for the CI `dbt test` step, part of the DPB-2504 secondary-roles-off initiative.

When the test role is used, the current `on-run-end` fires `CALL OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS()` regardless of the invoked command. The test role does not (and by design must not) have `USAGE` on that procedure, so `dbt test` fails with:

```
002141 (42601): SQL compilation error:
Unknown user-defined function OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS.
```

See failing run: https://github.com/colpal/analytics-md/actions/runs/29014375423/job/86108282156?pr=848#step:14:595

Since `dbt test` does not create or replace any Snowflake object, the CERTIFIED_READ grant reconciliation and tag reapplication both have nothing to do — the correct fix is to skip the hook, not to grant the read-only role a procedure it should never call.

Secondary benefits:
- Eliminates redundant proc CALLs on `parse`, `compile`, `docs generate`, `source freshness` (on 1.11), etc.
- Eliminates the wasted CALL on the CI's dedicated `dbt build --select package:dbt_project_evaluator+` step.

## Changes

**`dbt_project.yml`** — add `flags.WHICH in ['run','build','seed','snapshot','clone']` to both `on-run-end` entries. SBX/`_LAB_` guard preserved.

**`macros/apply_snowflake_tags.sql`** —
- Mirror the command guard inside `tag_models_from_results()` and `call_certified_read_proc()` as an early `return('')` with an `info` log. Belt-and-suspenders — any downstream project that adds these macros to its own `on-run-end` without the yaml guard is still protected.
- Add the metadata-package guard to both macros: filter successful nodes by `res.node.package_name not in ['dbt_project_evaluator']`; if zero user-project nodes remain, log SKIPPED and return before either reapplying tags or issuing the CERTIFIED_READ CALL.
- **`call_certified_read_proc` metadata-guard filter covers `resource_type in ('model', 'seed', 'snapshot')`** — the set of dbt resource types that materialize as grant-holding Snowflake objects. `dbt clone` inherits each cloned node's original resource_type, so this covers clones of any of the three. Restricting the filter to `model` alone would incorrectly skip the CALL on `dbt seed` / `dbt snapshot` runs whose results contain no model nodes.
- **`tag_models_from_results` metadata-guard filter keeps `resource_type == 'model'`** — its downstream `tag_models_on_run_end` iterates only models, so a broader filter would create a mismatch. Tag reapplication for seeds and snapshots is a pre-existing gap tracked outside this ticket.

## Regression-safety analysis

Both guards are strictly narrowing predicates — they can only turn `fire` into `skip`, never the reverse. So the question reduces to: **is there any command × repo combination where the pre-fix hook was doing necessary work that we would now block?**

The hook body does exactly two things:
1. `tag_models_from_results` iterates `results`, filters to successful models, invokes `tag_models_on_run_end` which re-issues `ALTER … SET TAG` DDL. Only relevant when a model was actually materialized (its underlying object was created/replaced, wiping tags).
2. `call_certified_read_proc` issues `CALL OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS()`, which reconciles `CERTIFIED_READ` grants across all `IS_CERTIFIED=TRUE` objects. Only relevant when a Snowflake object was created/replaced (wiping grants).

Non-mutating commands don't create or replace Snowflake objects, so neither reconciliation has anything to do on those commands. Safety net: `TAG_BASED_RBAC_CERT_PROC` runs hourly regardless — even if we skipped a legitimate reconciliation, drift is capped at ~60 min.

**Command coverage — deliberate omissions:**

The allow-list `['run','build','seed','snapshot','clone']` covers every dbt command in use in Colgate's dbt-common CI and Airflow orchestration. Explicit omissions:

- `retry` — verified via dbt-core 1.9.10 source (`core/dbt/cli/flags.py` sets `WHICH = ctx.info_name`; retry command name is `"retry"`, not the underlying failed command). Not used at Colgate; hourly safety-net task covers the theoretical drift window. Not added to allow-list.
- `run-operation` — bypassed intentionally. dbt-common's `dbt run-operation cp_dbt_standard_package.tag_models_on_run_end --args ...` invocation calls the tagging macro directly and does not depend on on-run-end.
- `docs serve` — no dbt run; filesystem serve only.

**Behavior change in `call_certified_read_proc` beyond "just skip evaluator builds":**

Disclosing openly. The pre-fix code called the CALL unconditionally on every on-run-end fire. Our new `grantable_nodes` filter skips the CALL whenever `results` contains no non-evaluator successful models, seeds, or snapshots. This is a superset of the evaluator-only case — it also covers:

- `dbt build --select ...` where the selector matched only evaluator nodes (intended).
- `dbt build --select ...` where the selector matched no nodes at all (safe — nothing to reconcile).
- Runs where all user-project models / seeds / snapshots failed (safe — grants weren't wiped on failed nodes; if a node succeeded its DROP but failed its CREATE, the object is gone and the CALL couldn't grant against it anyway).
- Runs that built only tests and no grant-holding nodes (safe — tests don't materialize Snowflake objects).

In each case the CALL was doing no useful work. The narrower `grantable_nodes > 0` guard is strictly more correct than the pre-fix "always fire" behavior.

## Verified behavior (local)

Tested locally against `EX_CUR_SBX` on both dbt versions the v2 fleet runs:

- **dbt-core 1.9.10 / dbt-snowflake 1.9.4** (matches analytics-md's `DBT_VERSION_TYPE`)
- **dbt-core 1.11.12 / dbt-snowflake 1.11.6**

| Command                                     | `GRANT_CERTIFIED_READ_ACCESS` proc | Notes                                                            |
| ------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------- |
| `parse`, `compile`, `test`, `docs generate` | Does not run                       | on-run-end fires but command guard skips                         |
| `source freshness`                          | Does not run                       | 1.11 fires on-run-end (guard skips); 1.9 doesn't fire at all     |
| `seed`, `build`, `run`                      | Runs (in prod)                     | Existing `SBX` / `_LAB_` guard still blocks sandbox targets      |
| `list`, `snapshot`, `show --inline`         | Does not run                       | on-run-end never fires                                           |
| `run-operation`                             | Does not run                       | `flags.WHICH='run-operation'`; CI's direct `tag_models_on_run_end` invocation bypasses on-run-end anyway |
| `deps`, `debug`, `clean`, `init`            | Does not run                       | Pre-flight / filesystem ops; no on-run-end                       |

Zero `002141` errors and zero certified-read CALLs observed across ~30 command invocations. On the mutating commands (`seed`, `build`, `run`) the `[WHICH_ONLY] BODY_ENTERED` diagnostic confirmed the command guard does not over-block.

**Test-scope limitation:** the local target was `EX_CUR_SBX`, which the existing `'SBX' not in target.database` yaml guard blocks regardless of the new `flags.WHICH` guard. So the local tests exercised the macro-level (belt-and-suspenders) guard cleanly but did not fully exercise the yaml-level `flags.WHICH` addition. Full yaml-guard exercise deferred to the canary CI checks below.

## Canary CI verification (pre-merge)

Two-repo canary running against the exact SHA of this PR (`8f04fbfcb6c135346011f223d643fffafdadfa40`):

- **analytics-ex** (owner: Anushka) — pin `packages.yml` in a throwaway PR; observe a normal push + PR CI cycle; log-diff against a control run on release/v2. Confirms no regression in a domain that isn't part of the DPB-2513 test-role rollout.
- **analytics-md** (owner: Brandon) — pin `packages.yml` + re-enable the reverted DPI secondary-role change (DPI PR #1056); confirm `dbt test` under `MD_TEST` succeeds where it previously failed with 002141. This is the actual end-to-end DPB-2513 unblock proof.

Handoff docs for both included in the linked Jira ticket.

## Idempotency

This change is idempotent because both guards are pure predicates over immutable inputs (`flags.WHICH` and the `results` list, both fixed for the current invocation). Running dbt N times with the same command against the same graph produces the same skip / call decision; when a guard fires, the skip is a no-op with zero Snowflake side effects.

## Out of scope (follow-up)

Per Anushka's comment on DPB-2513, the newer `apply_snowflake_tags.sql` on the `v2` git tag has a substantially rewritten `call_certified_read_proc` — DEPLOY/ELT role guard, `IS_CERTIFIED` graph walk, per-domain manifest, `_PR_`/`_PD` ephemeral dry-run, domain-scoped `GRANT_CERTIFIED_READ_ACCESS_BY_DOMAIN(db, json)` CALL, plus a sibling `call_cross_domain_read_proc()` macro and iceberg-aware `ALTER` in `apply_tag` / `apply_column_tag`. None of that is on `release/v2` today.

A separate epic will forward-port those changes onto `release/v2` while preserving the guards this PR introduces, and cross-repo-verify that `GRANT_CERTIFIED_READ_ACCESS_BY_DOMAIN` and `GRANT_CROSS_DOMAIN_READ_ACCESS_BY_DOMAIN` exist in `data-platforms-infrastructure` (`dev` + `prd`). This PR is the minimal unblock so the test-role PRs can proceed without changing the CERTIFIED_READ proc semantics.

## Post-merge

After merge and rolling tag bump on `release/v2`, re-enable the reverted MD secondary-role change ([DPI PR #1056](https://github.com/colpal/data-platforms-infrastructure/pull/1056) follow-up) and re-run the MD job that was failing with `002141` to confirm green under `MD_TEST`.

Made with [Cursor](https://cursor.com)

[DPB-2513]: https://cp9.atlassian.net/browse/DPB-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
