### PR TITLE
fix(DPB-2686): scope tag-DDL role switch by target database layer

### DIFF
--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -48,14 +48,30 @@
 
 {# ============================================================
    RESOLVE TAGGING ROLE
-   Tag DDL on CON-layer objects must run as the CON deploy role.
-   Swaps {domain}_DEPLOY_CUR -> {domain}_DEPLOY_CON.
+   Tag DDL must run as the role that owns the target object.
+   Uses the target database name (not just target.role) so a
+   CUR-session tagging CON-layer objects switches to CON, and a
+   CUR-session tagging CUR-layer objects (e.g. iceberg tables in
+   _PR_{N}_{DOMAIN}_CUR) does NOT switch. Iceberg tables enforce
+   strict OWNERSHIP for ALTER SET TAG, which is what surfaced this
+   bug in DPB-2591.
+
+   Layer inference (see data-platforms-infrastructure AGENTS.md):
+     {DOMAIN}_CUR / {DOMAIN}_CON                  (prod)
+     {DOMAIN}_CUR_PD / {DOMAIN}_CON_PD            (pre-deploy)
+     _PR_{N}_{DOMAIN}_CUR / _PR_{N}_{DOMAIN}_CON  (PR preview)
+   -> a trailing `_CON` or `_CON_PD` means CON layer; anything else CUR.
    Returns none if no switch is needed.
    ============================================================ #}
-{% macro get_tagging_role() %}
+{% macro get_tagging_role(database_nm) %}
     {% set current_role = target.role | upper %}
-    {% if '_DEPLOY_CUR' in current_role %}
+    {% set db_upper = database_nm | upper %}
+    {% set is_con_layer = db_upper.endswith('_CON') or db_upper.endswith('_CON_PD') %}
+
+    {% if is_con_layer and '_DEPLOY_CUR' in current_role %}
         {{ return(current_role | replace('_DEPLOY_CUR', '_DEPLOY_CON')) }}
+    {% elif (not is_con_layer) and '_DEPLOY_CON' in current_role %}
+        {{ return(current_role | replace('_DEPLOY_CON', '_DEPLOY_CUR')) }}
     {% endif %}
     {{ return(none) }}
 {% endmacro %}
@@ -171,7 +187,7 @@
        always restore the session role afterwards.
        -------------------------------------------------------- #}
     {% set original_role = target.role | upper %}
-    {% set tagging_role = cp_dbt_standard_package.get_tagging_role() %}
+    {% set tagging_role = cp_dbt_standard_package.get_tagging_role(database_nm) %}
 
     {% if tagging_role %}
         {{ log("Switching role " ~ original_role ~ " -> " ~ tagging_role ~ " for tag DDL", info=true) }}
@@ -257,7 +273,7 @@
        always restore the session role afterwards.
        -------------------------------------------------------- #}
     {% set original_role = target.role | upper %}
-    {% set tagging_role = cp_dbt_standard_package.get_tagging_role() %}
+    {% set tagging_role = cp_dbt_standard_package.get_tagging_role(database_nm) %}
     {% if tagging_role %}
         {{ log("Switching role " ~ original_role ~ " -> " ~ tagging_role ~ " for tag DDL", info=true) }}
         {% do run_query('USE ROLE ' ~ tagging_role) %}


### PR DESCRIPTION
## Summary

- `get_tagging_role()` in `macros/apply_snowflake_tags.sql` unconditionally swapped `_DEPLOY_CUR` -> `_DEPLOY_CON` based on session role alone, so post-build tag reapplication under `EX_DEPLOY_CUR` tried to run `ALTER SET TAG` on **CUR-layer objects** as `EX_DEPLOY_CON`.
- Iceberg tables enforce strict OWNERSHIP for `ALTER SET TAG`, so what silently worked for non-iceberg CUR tables (via inherited ALTER privileges) became a hard `003001 (42501)` failure on analytics-ex PR [#800](https://github.com/colpal/analytics-ex/pull/800) (DPB-2591) against `_PR_800_EX_CUR.MARTS_TEST.FCT_TEST`.
- Fix: pass `database_nm` into `get_tagging_role` and infer CUR vs CON from the trailing database suffix (`_CON` / `_CON_PD` -> CON, else CUR). Only switch when the current session role does not match the target object's owning role.

## Failing log excerpt (before fix)

```
Processing model: _PR_800_EX_CUR.marts_test.fct_test
Switching role EX_DEPLOY_CUR -> EX_DEPLOY_CON for tag DDL
Encountered an error while running operation: Database Error
  003001 (42501): SQL access control error:
  Insufficient privileges to operate on iceberg_table 'FCT_TEST'.
  Your primary role EX_DEPLOY_CON must have OWNERSHIP granted on
  TABLE _PR_800_EX_CUR.MARTS_TEST.FCT_TEST.
```

## What changed

- `macros/apply_snowflake_tags.sql`
  - `get_tagging_role()` -> `get_tagging_role(database_nm)`, layer-aware (CUR vs CON), with a symmetric branch that also handles CON-session tagging CUR objects.
  - Both call sites in `apply_tag` and `apply_column_tag` now pass `database_nm`.
  - No changes to the log line, `USE ROLE`, `ALTER`, or the restore-role block. Restore already lives inside `if tagging_role`, so it is naturally skipped when no switch was needed.

## Expected behavior after fix

| Target DB layer | Session role | Behavior |
|---|---|---|
| CUR (`_PR_N_EX_CUR`, `EX_CUR`, `EX_CUR_PD`) | `EX_DEPLOY_CUR` | No switch, ALTER runs as CUR (owner) |
| CON (`_PR_N_EX_CON`, `EX_CON`, `EX_CON_PD`) | `EX_DEPLOY_CUR` | Switch to `EX_DEPLOY_CON`, ALTER runs as CON (owner), role restored |
| CUR | `EX_DEPLOY_CON` | Switch to `EX_DEPLOY_CUR`, ALTER runs as CUR (owner), role restored |
| CON | `EX_DEPLOY_CON` | No switch |

## Idempotency

`get_tagging_role` is a pure function of `(target.role, database_nm)`, `USE ROLE` on the already-active role is a session no-op, and the original role is unconditionally restored after each ALTER inside the same `if tagging_role` guard. Running the tag hook twice produces the same session state and the same tags.

## Test plan

Validation happens on analytics-ex PR [#800](https://github.com/colpal/analytics-ex/pull/800) by pointing its `dbt/packages.yml` `revision` at this branch (or at `integration/sv-v2.1.0` once merged) and re-running CI. Expected signals in the tag-deploy step log:

- [ ] `_PR_800_EX_CUR.marts_test.fct_test` (CUR iceberg): NO `Switching role` line, `Applied column tag 'IS_UNVERIFIED' to src in marts_test.fct_test` succeeds.
- [ ] `_PR_800_EX_CON.marts_test.<con_model>` (CON): `Switching role EX_DEPLOY_CUR -> EX_DEPLOY_CON for tag DDL` still present, `Applied column tag ...` succeeds.
- [ ] Workflow exits 0, no `003001` in the tag step.

## Related

- Jira: [DPB-2686](https://cp9.atlassian.net/browse/DPB-2686)
- Relates to: [DPB-2591](https://cp9.atlassian.net/browse/DPB-2591) / analytics-ex PR #800

Made with [Cursor](https://cursor.com)

[DPB-2686]: https://cp9.atlassian.net/browse/DPB-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ