### PR TITLE
fix(DPB-2513): gate on-run-end hooks by command + package (v2 recovery)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,9 +27,32 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   +transient: false
 
-# Automatically reapply Snowflake tags after every dbt run (fixes tag loss on view recreation)
+# Reapply Snowflake tags + reconcile CERTIFIED_READ / CROSS_DOMAIN_READ grants
+# after object-mutating dbt runs.
+#
+# DPB-2513: Gate on flags.WHICH so hooks fire ONLY for commands that create or
+# replace Snowflake objects (run, build, seed, snapshot, clone).
+#
+# Skipped commands (test, compile, parse, deps, list, docs, debug, show, clean,
+# init, source freshness, retry, run-operation, source ...) do not touch object
+# DDL — tag reapplication and grant reconciliation have nothing to reconcile.
+# This also:
+#   - unblocks per-domain read-only test roles (e.g. <DOMAIN>_TEST) which must
+#     not hold USAGE on OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS_BY_DOMAIN
+#     and would otherwise fail `dbt test` with 002141 "Unknown user-defined
+#     function".
+#   - prevents `dbt source freshness` (which runs on-run-end hooks by default
+#     as of dbt-core 1.10 — flag removed entirely in v2.0) from firing the
+#     grant procs on every source-freshness check.
+#
+# SBX / _LAB_ guard: sandbox and lab databases are analyst-owned; skip both
+# tagging and grant reconciliation there.
+#
+# Belt-and-suspenders: each macro also carries its own flags.WHICH guard in
+# apply_snowflake_tags.sql so any downstream project that wires these into
+# their own on-run-end without the yaml guard still gets correct behavior.
 on-run-end:
-  - "{% if 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.tag_models_from_results() }}{% endif %}"
-  - "{% if 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.call_certified_read_proc() }}{% endif %}"
-  - "{% if 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.call_cross_domain_read_proc() }}{% endif %}"
+  - "{% if flags.WHICH in ['run','build','seed','snapshot','clone'] and 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.tag_models_from_results() }}{% endif %}"
+  - "{% if flags.WHICH in ['run','build','seed','snapshot','clone'] and 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.call_certified_read_proc() }}{% endif %}"
+  - "{% if flags.WHICH in ['run','build','seed','snapshot','clone'] and 'SBX' not in target.database | upper and '_LAB_' not in target.database | upper %}{{ cp_dbt_standard_package.call_cross_domain_read_proc() }}{% endif %}"
 

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -378,13 +378,43 @@
 
 {# ============================================================
    AUTO-TAG FROM RUN RESULTS (on-run-end)
-   Called automatically by on-run-end hook to reapply tags after dbt runs
+   Called automatically by on-run-end hook to reapply tags after dbt runs.
+
+   DPB-2513 guards, in order:
+     1. Command guard: skip when the current dbt invocation cannot have
+        created or replaced Snowflake objects (test / compile / parse /
+        deps / list / docs / debug / show / clean / init / source ...).
+        Belt-and-suspenders with the yaml-level guard in dbt_project.yml —
+        protects any downstream project that wires this macro into
+        on-run-end without the yaml guard, and covers `dbt source freshness`
+        (which runs on-run-end hooks by default as of dbt-core 1.10; the
+        `source_freshness_run_project_hooks` flag was removed in v2.0).
+     2. Metadata-package guard: skip when the only successful models were
+        from `dbt_project_evaluator`. dbt-common CI runs that package as its
+        own dedicated `dbt build --select package:dbt_project_evaluator+`
+        step; its models never carry `snowflake_tags`, so there is nothing
+        to reapply. Extend the ignore list if new metadata-only packages
+        (e.g. elementary) are added to CI.
    ============================================================ #}
 {% macro tag_models_from_results() %}
     {% if execute %}
+        {% set object_mutating_cmds = ['run', 'build', 'seed', 'snapshot', 'clone'] %}
+        {% if flags.WHICH not in object_mutating_cmds %}
+            {{ log(
+                "[tag_models_from_results] SKIPPED | command '" ~ flags.WHICH
+                ~ "' does not create or replace Snowflake objects — nothing to tag."
+                ~ " Hook only fires for: " ~ object_mutating_cmds | join(', '),
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
+
+        {% set ignore_packages = ['dbt_project_evaluator'] %}
         {% set successful_models = [] %}
         {% for res in results %}
-            {% if res.node.resource_type == 'model' and res.status in ['success', 'pass'] %}
+            {% if res.node.resource_type == 'model'
+              and res.status in ['success', 'pass']
+              and res.node.package_name not in ignore_packages %}
                 {% do successful_models.append(res.node.unique_id) %}
             {% endif %}
         {% endfor %}
@@ -393,7 +423,11 @@
             {{ log("Auto-tagging " ~ successful_models | length ~ " deployed model(s)", info=true) }}
             {{ cp_dbt_standard_package.tag_models_on_run_end(successful_models) }}
         {% else %}
-            {{ log("No successfully deployed models to tag.", info=true) }}
+            {{ log(
+                "[tag_models_from_results] SKIPPED | no user-project models successfully built"
+                ~ " (ignoring packages: " ~ ignore_packages | join(', ') ~ ") — nothing to tag.",
+                info=true
+            ) }}
         {% endif %}
     {% endif %}
 {% endmacro %}
@@ -420,9 +454,68 @@
    The legacy 0-arg GRANT_CERTIFIED_READ_ACCESS() procedure continues
    to run on its hourly Snowflake Task, acting as a safety net for
    objects tagged directly in Snowflake (outside of dbt runs).
+
+   DPB-2513 guards (evaluated before role/graph iteration):
+     1. Command guard: skip when the current dbt invocation cannot have
+        created or replaced Snowflake objects (test / compile / parse /
+        deps / list / docs / debug / show / clean / init / source ...).
+        Primary blocker for the per-domain <DOMAIN>_TEST role rollout —
+        the read-only test role must not require USAGE on
+        OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS_BY_DOMAIN.
+        Also prevents `dbt source freshness` (hooks now run by default
+        in dbt-core 1.10+; flag removed in v2.0) from firing the CALL
+        on every freshness check. Belt-and-suspenders with the yaml-
+        level guard in dbt_project.yml.
+     2. Metadata-package guard: skip when the only successful grant-
+        holding nodes (models, seeds, snapshots) were from
+        `dbt_project_evaluator`. CI's `dbt build --select
+        package:dbt_project_evaluator+` step never touches nodes that
+        carry IS_CERTIFIED, so CERTIFIED_READ grants cannot have been
+        wiped — the CALL would be wasted. Extend the ignore list if new
+        metadata-only packages are added to CI.
+
+        Filter covers `model`, `seed`, and `snapshot` because each
+        materializes as a Snowflake table/view that can hold an
+        IS_CERTIFIED tag and therefore CERTIFIED_READ grants.
+        Restricting to `model` alone incorrectly skipped the CALL on
+        `dbt seed` / `dbt snapshot` runs (DPB-2513 8f04fbf).
    ============================================================ #}
 {% macro call_certified_read_proc() %}
     {% if execute %}
+
+        {% set object_mutating_cmds = ['run', 'build', 'seed', 'snapshot', 'clone'] %}
+        {% if flags.WHICH not in object_mutating_cmds %}
+            {{ log(
+                "[call_certified_read_proc] SKIPPED | command '" ~ flags.WHICH
+                ~ "' does not create or replace Snowflake objects — CERTIFIED_READ grants"
+                ~ " cannot have been wiped by this run. Hook only fires for: "
+                ~ object_mutating_cmds | join(', '),
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
+
+        {% set ignore_packages = ['dbt_project_evaluator'] %}
+        {% set grantable_resource_types = ('model', 'seed', 'snapshot') %}
+        {% set grantable_nodes = [] %}
+        {% for res in results %}
+            {% if res.node.resource_type in grantable_resource_types
+              and res.status in ['success', 'pass']
+              and res.node.package_name not in ignore_packages %}
+                {% do grantable_nodes.append(res.node.unique_id) %}
+            {% endif %}
+        {% endfor %}
+        {% if grantable_nodes | length == 0 %}
+            {{ log(
+                "[call_certified_read_proc] SKIPPED | no user-project "
+                ~ grantable_resource_types | join(' / ')
+                ~ " successfully built (ignoring packages: "
+                ~ ignore_packages | join(', ')
+                ~ ") — CERTIFIED_READ grants cannot have been wiped by this run.",
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
 
         {# ---------------------f-----------------------------------
            Role guard: fire for DEPLOY roles (CI/CD) and ELT roles (Airflow).
@@ -652,9 +745,66 @@
    The legacy 0-arg GRANT_CROSS_DOMAIN_READ_ACCESS() procedure continues
    to run on its hourly Snowflake Task, acting as a safety net for
    objects tagged directly in Snowflake (outside of dbt runs).
+
+   DPB-2513 guards (evaluated before role/graph iteration):
+     1. Command guard: skip when the current dbt invocation cannot have
+        created or replaced Snowflake objects (test / compile / parse /
+        deps / list / docs / debug / show / clean / init / source ...).
+        Prevents `dbt source freshness` (hooks now run by default in
+        dbt-core 1.10+; flag removed in v2.0) from firing the CALL on
+        every freshness check. Also required for the per-domain
+        <DOMAIN>_TEST role rollout — the read-only test role must not
+        require USAGE on
+        OPS_CUR.UTIL_COMMON.GRANT_CROSS_DOMAIN_READ_ACCESS_BY_DOMAIN.
+        Belt-and-suspenders with the yaml-level guard in dbt_project.yml.
+     2. Metadata-package guard: skip when the only successful grant-
+        holding nodes (models, seeds, snapshots) were from
+        `dbt_project_evaluator`. CI's `dbt build --select
+        package:dbt_project_evaluator+` step never touches nodes that
+        carry CROSS_DOMAIN, so CROSS_DOMAIN_READ grants cannot have been
+        wiped — the CALL would be wasted. Extend the ignore list if new
+        metadata-only packages are added to CI.
+
+        Filter covers `model`, `seed`, and `snapshot` because each
+        materializes as a Snowflake table/view that can hold a
+        CROSS_DOMAIN tag and therefore CROSS_DOMAIN_READ grants.
    ============================================================ #}
 {% macro call_cross_domain_read_proc() %}
     {% if execute %}
+
+        {% set object_mutating_cmds = ['run', 'build', 'seed', 'snapshot', 'clone'] %}
+        {% if flags.WHICH not in object_mutating_cmds %}
+            {{ log(
+                "[call_cross_domain_read_proc] SKIPPED | command '" ~ flags.WHICH
+                ~ "' does not create or replace Snowflake objects — CROSS_DOMAIN_READ grants"
+                ~ " cannot have been wiped by this run. Hook only fires for: "
+                ~ object_mutating_cmds | join(', '),
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
+
+        {% set ignore_packages = ['dbt_project_evaluator'] %}
+        {% set grantable_resource_types = ('model', 'seed', 'snapshot') %}
+        {% set grantable_nodes = [] %}
+        {% for res in results %}
+            {% if res.node.resource_type in grantable_resource_types
+              and res.status in ['success', 'pass']
+              and res.node.package_name not in ignore_packages %}
+                {% do grantable_nodes.append(res.node.unique_id) %}
+            {% endif %}
+        {% endfor %}
+        {% if grantable_nodes | length == 0 %}
+            {{ log(
+                "[call_cross_domain_read_proc] SKIPPED | no user-project "
+                ~ grantable_resource_types | join(' / ')
+                ~ " successfully built (ignoring packages: "
+                ~ ignore_packages | join(', ')
+                ~ ") — CROSS_DOMAIN_READ grants cannot have been wiped by this run.",
+                info=true
+            ) }}
+            {{ return('') }}
+        {% endif %}
 
         {# --------------------------------------------------------
            Role guard: fire for DEPLOY roles (CI/CD) and ELT roles (Airflow).


### PR DESCRIPTION
## Summary

**DPB-2513 recovery.** The original DPB-2513 refactor ([PR #81](https://github.com/colpal/cp-dbt-standard-package/pull/81)) was authored on 2026-07-10 but never merged forward — it's stranded on `bugfix/DPB-2513.gate-on-run-end-hooks-by-command` and is missing from both `release/v2` and `integration/sv-v2.1.0`. In the meantime the DPB-2686 rework rewrote both existing hooks and PR #82 added a third (`call_cross_domain_read_proc`), so a straight cherry-pick of PR #81 no longer applies.

This PR re-implements the DPB-2513 pattern against the current proc-by-domain shape for **all three** on-run-end macros, with **belt-and-suspenders** guarding at both the yaml hook level and inside each macro. PR #81 will be closed with a link to this PR.

## Why now

Since PR #81 stalled, the stable dbt-common image jumped from 1.9 → 1.10, which flips the default of `source_freshness_run_project_hooks` from `false` to `true` (the flag is removed entirely in dbt-core v2.0). That means **every `dbt source freshness` invocation from Airflow / dbt Cloud has been firing `call_certified_read_proc()` and `call_cross_domain_read_proc()`** despite no Snowflake object having been mutated. Pure wasted `SNOWFLAKE.ACCOUNT_USAGE.TAG_REFERENCES` scans + reconciliation queries per poll.

Discovered while reviewing PR #67 / [PR #84](https://github.com/colpal/cp-dbt-standard-package/pull/84) — [user] flagged that a "destructive-command-only" gate had been designed but not landed on the current release line.

## Guards

### Guard 1 — command guard (yaml + macro, belt-and-suspenders)

```jinja
{% if flags.WHICH in ['run', 'build', 'seed', 'snapshot', 'clone'] %}
```

Everything else (`test`, `compile`, `parse`, `deps`, `list`, `docs`, `debug`, `show`, `clean`, `init`, `source freshness`, `retry`, `run-operation`) short-circuits with an info log. The yaml guard skips the macro call entirely; the in-macro guard protects any downstream project that wires these macros into its own `on-run-end` without the yaml guard.

### Guard 2 — metadata-package guard (macros only, evaluated after Guard 1)

Filter `results` by:

| Filter | Value |
|---|---|
| `resource_type` (grant procs) | `('model', 'seed', 'snapshot')` |
| `resource_type` (tagging) | `'model'` |
| `status` | `in ['success', 'pass']` |
| `package_name` | `not in ['dbt_project_evaluator']` |

If the resulting list is empty, log SKIPPED and return.

The grant-proc filter covers `seed` and `snapshot` because both materialize as grant-holding Snowflake objects — restricting to `model` alone would incorrectly skip the CALL on `dbt seed` / `dbt snapshot` runs (DPB-2513 `8f04fbf`). `tag_models_from_results` intentionally stays model-only — its downstream `tag_models_on_run_end` iterates only models.

## What this fixes

| Invocation | Before | After |
|---|---|---|
| `dbt source freshness` (Airflow / dbt Cloud) | Fired both grant procs on every poll | Skipped with log |
| `dbt test` on `<DOMAIN>_TEST` role | Failed with `002141 Unknown user-defined function` because the role lacks USAGE on `GRANT_*_ACCESS_BY_DOMAIN` | Skipped before the CALL is compiled |
| `dbt build --select package:dbt_project_evaluator+` (CI step) | Fired grant procs even though no user-project models were built | Skipped with log |
| `dbt compile` / `dbt parse` / `dbt list` / `dbt docs generate` | Fired tagging + grant CALLs identically to `dbt run` | Skipped with log |
| `dbt run` / `dbt build` / `dbt seed` / `dbt snapshot` / `dbt clone` | Unchanged | Unchanged |

## Test plan

- [ ] Run `dbt source freshness` in a domain repo pinned to this branch — expect three `SKIPPED | command 'source'` log lines and no `CALL OPS_CUR.UTIL_COMMON.GRANT_*_ACCESS_BY_DOMAIN` in the log.
- [ ] Run `dbt test` with a `<DOMAIN>_TEST` role — expect no `002141` and three SKIPPED log lines.
- [ ] Run `dbt build --select package:dbt_project_evaluator+` — expect the command guard to pass but the package guard to skip both grant procs with an info log.
- [ ] Run `dbt build` targeting a user-project model — expect all three hooks to fire normally.
- [ ] Run `dbt compile` — expect three SKIPPED log lines.
- [ ] Run `dbt seed` — expect the grant procs to fire (seeds are in the `grantable_resource_types` set).

## Idempotency

This change is idempotent because it strictly narrows when the on-run-end side effects fire — applying the change twice produces the same skip / call decision for any given run. `flags.WHICH` is immutable for a given invocation; the filter on `results` is deterministic.

## Related

- Closes: [PR #81](https://github.com/colpal/cp-dbt-standard-package/pull/81) (the original DPB-2513 PR that stalled)
- Flows into: [PR #67](https://github.com/colpal/cp-dbt-standard-package/pull/67) via `integration/sv-v2.1.0`
- Discovered via: [PR #84](https://github.com/colpal/cp-dbt-standard-package/pull/84) review
