### PR TITLE
fix: make Snowflake tagging macros compatible with the dbt Fusion engine

### DIFF
--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -55,6 +55,10 @@
         SHOW TAGS IN SCHEMA {{ config.tag_database }}.{{ config.tag_schema }}
     {% endset %}
 
+    {% if not execute %}
+        {{ return([]) }}
+    {% endif %}
+
     {% set rows = run_query(sql) %}
     {% set tag_list = [] %}
 
@@ -115,7 +119,7 @@
 
     {% if not ns.tag_exists %}
         {{ log("ERROR: Tag '" ~ tag_name ~ "' doesn't exist in Snowflake. Skipping.", info=true) }}
-        {{ return() }}
+        {{ return(none) }}
     {% endif %}
 
     {% set tag_name = ns.matching_tag %}
@@ -134,7 +138,7 @@
         {% if not val_ns.is_valid %}
             {{ log("ERROR: Value '" ~ tag_value ~ "' not allowed for tag '" ~ tag_name ~ "'.", info=true) }}
             {{ log("Allowed values: " ~ ns.allowed_values | join(', '), info=true) }}
-            {{ return() }}
+            {{ return(none) }}
         {% endif %}
 
         {% set tag_value = val_ns.matched_value %}
@@ -179,7 +183,7 @@
 
     {% if not ns.tag_exists %}
         {{ log("ERROR: Column tag '" ~ tag_name ~ "' doesn't exist in Snowflake. Skipping.", info=true) }}
-        {{ return() }}
+        {{ return(none) }}
     {% endif %}
 
     {% set tag_name = ns.matching_tag %}
@@ -197,7 +201,7 @@
         {% if not val_ns.is_valid %}
             {{ log("ERROR: Value '" ~ tag_value ~ "' not allowed for column tag '" ~ tag_name ~ "'.", info=true) }}
             {{ log("Allowed values: " ~ ns.allowed_values | join(', '), info=true) }}
-            {{ return() }}
+            {{ return(none) }}
         {% endif %}
 
         {% set tag_value = val_ns.matched_value %}

--- a/macros/cp_apply_snowflake_tags.sql
+++ b/macros/cp_apply_snowflake_tags.sql
@@ -118,7 +118,7 @@
         {% if not val_ns.is_valid %}
             {{ log("ERROR: Value '" ~ tag_value ~ "' not in allowed values for tag '" ~ tag_name ~ "'. Tag will NOT be applied.", info=true) }}
             {{ log("Allowed values: " ~ ns.allowed_values | join(', '), info=true) }}
-            {{ return() }}
+            {{ return(none) }}
         {% endif %}
         
         {# use the matched value #}
@@ -164,7 +164,7 @@
     {# mismatch error #}
     {% if not ns.tag_exists %}
         {{ log("ERROR: Tag '" ~ tag_name ~ "' doesn't exist in Snowflake. Column tag will NOT be applied.", info=true) }}
-        {{ return() }}
+        {{ return(none) }}
     {% endif %}
     
     {# use the matched tag name for all further operations #}
@@ -184,7 +184,7 @@
         {% if not val_ns.is_valid %}
             {{ log("ERROR: Value '" ~ tag_value ~ "' not in allowed values for tag '" ~ tag_name ~ "'. Column tag will NOT be applied.", info=true) }}
             {{ log("Allowed values: " ~ ns.allowed_values | join(', '), info=true) }}
-            {{ return() }}
+            {{ return(none) }}
         {% endif %}
         
         {# use the matched value #}


### PR DESCRIPTION
## What's broken

Any project that consumes `cp_dbt_standard_package` on `release/v2` cannot run on the **dbt Fusion engine**. Parsing fails immediately with:

```
error: dbt1501: Failed to add template invalid operation: Incorrect return argument count
(in cp_dbt_standard_package.apply_column_tag:18:9)
```

This blocks all Fusion adoption downstream, including the new official dbt VS Code extension, which won't start its language server if the project can't parse. On `analytics-md` this meant zero Fusion features across 594 models.

## Why it happens

The tagging macros exit early by calling `return()` with no arguments:

```jinja
{% if not ns.tag_exists %}
    {{ log("ERROR: Tag '" ~ tag_name ~ "' doesn't exist in Snowflake. Skipping.", info=true) }}
    {{ return() }}
{% endif %}
```

dbt Core 1.x runs Jinja in Python and tolerates a bare `return()`. Fusion is written in Rust and enforces the documented signature, which takes exactly one argument. So the same macro that works today on Core is a hard parse error on Fusion.

There are seven of these, all in the two tagging macro files.

## What this PR changes

Two things, both small:

1. **`return()` becomes `return(none)`** in all seven places. `none` is the value Python-Jinja was implicitly returning anyway, so the early-exit behavior is byte-for-byte identical on dbt Core 1.x. Nothing about tag validation, allowed-value matching, or logging changes.

2. **`get_snowflake_tags` no longer runs `SHOW TAGS` at parse time.** The macro is reached during parsing, when `execute` is false and there is no warehouse connection to query. An `{% if not execute %}{{ return([]) }}{% endif %}` guard before `run_query` returns an empty tag list in that phase. Returning `[]` rather than `none` matters because every caller iterates the result. This is standard dbt practice for macros that call `run_query`.

Total diff: 11 insertions, 7 deletions, across 2 files. No behavior change for existing dbt Core users, no version bump, no new dependencies.

## Testing

Verified against `analytics-md` (594 models, 66 snapshots, 3,319 data tests, Snowflake):

| Engine | Before | After |
| --- | --- | --- |
| dbt Fusion `2.0.0-preview.203` | `dbt1501` error, parse aborts | Parses clean in 3.0s |
| dbt Core `1.11.11` | Parses clean | Parses clean, no new deprecations |

The dbt Core check is the important one: it confirms this is safe to merge for every team still on Core, since they are the current consumers of `release/v2`.

## Relationship to the existing `DPB-1959_dbt_fusion_wo_brooklyn_package` branch

That branch already contains the same `return(none)` fix and the same `execute` guard, so credit for the approach belongs there. I have deliberately not proposed merging it, for two reasons:

- It is **based on an older `release/v2`** and would regress features added since, including `.strip()` whitespace handling on tag names and values, the optional `relation_type` argument that avoids an `adapter.get_relation` call per model, `tag_models_from_results`, `call_certified_read_proc`, and reading tags from `config.meta.snowflake_tags`.
- It also **removes the Brooklyn `dbt_artifacts` package** and bumps `dbt_project_evaluator`. Those are reasonable changes but they are independent decisions, and consumers like `analytics-md` still wire up `dbt_artifacts` through `DBT_ARTIFACTS_DATABASE`, so removing it deserves its own discussion.

This PR is the Fusion fix in isolation, rebased onto current `release/v2`, so it can merge without waiting on those larger questions.

## Reviewer notes

- No ticket number: happy to move this under a `DPB-` branch name if that's required by convention.
- If you'd prefer a version bump on `dbt_project.yml` (currently `2.6.2`) as part of this, say the word and I'll add it.

Made with [Cursor](https://cursor.com)