### PR TITLE
feat(DPB-2846): infer SECURITY_LEVEL from column PII_LEVEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,31 @@ packages:
 
 We need to set the `DBT_ARTIFACTS_DATABASE` and  `DBT_ARTIFACTS_SCHEMA` environment variable to the name of a database where you have write permissions. When this variable is set, dbt will use the database and schema to store all artifacts.
 Dbt artifacts are the output of dbt runs, such as compiled SQL queries, dbt run, dbt snapshots, dbt seed etc.
+
+## Snowflake column tags — PII_LEVEL → SECURITY_LEVEL (DPB-2846)
+
+Column-scoped only. When a column declares `PII_LEVEL` under `meta.snowflake_tags`, `tag_models_on_run_end` derives and co-applies `SECURITY_LEVEL`:
+
+| PII_LEVEL | Inferred SECURITY_LEVEL |
+|---|---|
+| `L1`, `L2` | `RESTRICTED` |
+| `L3A`, `L3B` | `HIGHLY_RESTRICTED` |
+
+```yaml
+columns:
+  - name: email_address
+    meta:
+      snowflake_tags:
+        PII_LEVEL: L2
+        # SECURITY_LEVEL: RESTRICTED is inferred and applied automatically
+```
+
+Rules:
+
+- Explicit `SECURITY_LEVEL` that matches the inference is accepted (idempotent).
+- Explicit `SECURITY_LEVEL` that conflicts with the inference raises a compiler error and fails the dbt run.
+- Unsupported `PII_LEVEL` values raise a compiler error.
+- Non-PII restricted columns may set `SECURITY_LEVEL` directly without `PII_LEVEL`.
+- Do not set an `IS_PII` boolean tag.
+
+Snowflake tag objects (`OPS_CUR.TAGS.SECURITY_LEVEL`, `OPS_CUR.TAGS.PII_LEVEL`) are provisioned in `data-platforms-infrastructure` (DPB-2844 Variant 2).

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'cp_dbt_standard_package'
-version: '2.6.2'
+version: '2.6.3'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -21,6 +21,12 @@
              meta:
                snowflake_tags:
                  TAG_NAME: 'tag_value_a'
+                 # DPB-2846 — PII classification (column-scoped only):
+                 #   PII_LEVEL: L1 | L2  -> SECURITY_LEVEL RESTRICTED (inferred)
+                 #   PII_LEVEL: L3A | L3B -> SECURITY_LEVEL HIGHLY_RESTRICTED
+                 # Explicit SECURITY_LEVEL must match the inferred value or the
+                 # dbt run fails. Non-PII restricted columns may set
+                 # SECURITY_LEVEL directly without PII_LEVEL.
 
   -----------------------------------------------
 #}
@@ -269,10 +275,17 @@
                     {% endfor %}
                 {% endif %}
 
-                {# Column-level tags #}
+                {# Column-level tags.
+                   DPB-2846: resolve PII_LEVEL -> SECURITY_LEVEL (and hard-fail
+                   on conflict) before applying any column tags. #}
                 {% for col_name, col in node.columns.items() %}
                     {% if col.meta is defined and col.meta.snowflake_tags is defined %}
-                        {% for tag_name, tag_value in col.meta.snowflake_tags.items() %}
+                        {% set resolved_tags = cp_dbt_standard_package.resolve_column_snowflake_tags(
+                            col.meta.snowflake_tags,
+                            column_name=col_name,
+                            model_name=model_name
+                        ) %}
+                        {% for tag_name, tag_value in resolved_tags.items() %}
                             {{ cp_dbt_standard_package.apply_column_tag(model_database, model_schema, model_name, col_name, tag_name, tag_value, rel_type) }}
                         {% endfor %}
                     {% endif %}

--- a/macros/infer_security_level_from_pii_level.sql
+++ b/macros/infer_security_level_from_pii_level.sql
@@ -1,0 +1,80 @@
+{# ============================================================
+   DPB-2846 — Infer SECURITY_LEVEL from PII_LEVEL
+
+   Mapping (locked):
+     L1, L2   -> RESTRICTED
+     L3A, L3B -> HIGHLY_RESTRICTED
+
+   Pure function. Raises a compiler error for unsupported values so a
+   PII-tagged column can never leave SECURITY_LEVEL unset.
+   ============================================================ #}
+{% macro infer_security_level_from_pii_level(pii_level) %}
+    {% set level = (pii_level | string | trim | upper) %}
+
+    {% if level in ['L1', 'L2'] %}
+        {{ return('RESTRICTED') }}
+    {% elif level in ['L3A', 'L3B'] %}
+        {{ return('HIGHLY_RESTRICTED') }}
+    {% else %}
+        {{ exceptions.raise_compiler_error(
+            "Unsupported PII_LEVEL '" ~ pii_level
+            ~ "'. Allowed values: L1, L2, L3A, L3B (DPB-2846)."
+        ) }}
+    {% endif %}
+{% endmacro %}
+
+
+{# ============================================================
+   Resolve column snowflake_tags for Variant 2 tagging.
+
+   Given a column's snowflake_tags dict:
+     - If PII_LEVEL is present, derive SECURITY_LEVEL.
+     - If SECURITY_LEVEL is also present and matches the derived value,
+       keep it (idempotent).
+     - If SECURITY_LEVEL is present and conflicts with the derived value,
+       raise_compiler_error (hard-fail the dbt run).
+     - If only SECURITY_LEVEL is present (no PII_LEVEL), leave tags as-is
+       so non-PII restricted data can still be tagged directly.
+   ============================================================ #}
+{% macro resolve_column_snowflake_tags(column_tags, column_name=none, model_name=none) %}
+    {% set resolved = {} %}
+    {% for tag_name, tag_value in column_tags.items() %}
+        {% do resolved.update({tag_name: tag_value}) %}
+    {% endfor %}
+
+    {% set ns = namespace(pii_key=none, security_key=none) %}
+    {% for tag_name in column_tags.keys() %}
+        {% if (tag_name | string | trim | upper) == 'PII_LEVEL' %}
+            {% set ns.pii_key = tag_name %}
+        {% elif (tag_name | string | trim | upper) == 'SECURITY_LEVEL' %}
+            {% set ns.security_key = tag_name %}
+        {% endif %}
+    {% endfor %}
+
+    {% if ns.pii_key is not none %}
+        {% set inferred = cp_dbt_standard_package.infer_security_level_from_pii_level(column_tags[ns.pii_key]) %}
+        {% set scope = '' %}
+        {% if model_name is not none and column_name is not none %}
+            {% set scope = " on " ~ model_name ~ "." ~ column_name %}
+        {% elif column_name is not none %}
+            {% set scope = " on column " ~ column_name %}
+        {% endif %}
+
+        {% if ns.security_key is not none %}
+            {% set explicit = (column_tags[ns.security_key] | string | trim | upper) %}
+            {% if explicit != inferred %}
+                {{ exceptions.raise_compiler_error(
+                    "SECURITY_LEVEL conflict" ~ scope
+                    ~ ": explicit value '" ~ column_tags[ns.security_key]
+                    ~ "' does not match SECURITY_LEVEL '" ~ inferred
+                    ~ "' inferred from PII_LEVEL '" ~ column_tags[ns.pii_key]
+                    ~ "'. Remove the conflicting SECURITY_LEVEL or change PII_LEVEL (DPB-2846)."
+                ) }}
+            {% endif %}
+        {% else %}
+            {% do resolved.update({'SECURITY_LEVEL': inferred}) %}
+        {% endif %}
+    {% endif %}
+
+    {{ return(resolved) }}
+{% endmacro %}


### PR DESCRIPTION
## Summary
- Adds `infer_security_level_from_pii_level` / `resolve_column_snowflake_tags` for Variant 2 column tagging under DPB-2844.
- Mapping: `L1`/`L2` → `RESTRICTED`; `L3A`/`L3B` → `HIGHLY_RESTRICTED`.
- Conflicting explicit `SECURITY_LEVEL` or unsupported `PII_LEVEL` hard-fails the dbt run via `raise_compiler_error`.
- Documents usage in README; bumps package version to `2.6.3`.

## Test plan
- [ ] `dbt run-operation cp_dbt_standard_package.infer_security_level_from_pii_level --args '{"pii_level":"L2"}'` returns `RESTRICTED`
- [ ] Column with only `PII_LEVEL: L3A` gets `SECURITY_LEVEL=HIGHLY_RESTRICTED` applied on tag run
- [ ] Column with `PII_LEVEL: L1` + `SECURITY_LEVEL: HIGHLY_RESTRICTED` fails tagging step
- [ ] Confirm no `dbt-common` change needed (existing `tag_models_on_run_end` invoke path)

Depends on DPI tags existing in `OPS_CUR.TAGS` after [#1209](https://github.com/colpal/data-platforms-infrastructure/pull/1209) apply. Do not cut a rolling tag until after merge coordination with the dbt-common team.