### PR TITLE
feat(DPB-2838): gate certified read post-hook on certified consumption models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'cp_dbt_standard_package'
-version: '2.6.2'
+version: '2.6.3'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -2,7 +2,7 @@
   Snowflake Tagging Package (`dbt_snowflake_tagging`)
   ----------------------------------------------------
     A set of macros to apply centrally created Snowflake tags to dbt models and columns
-    based on configurations in schema YAML files.
+    based on configurations in schema YAML files
 
   Version: 1.0.0
 

--- a/macros/apply_snowflake_tags.sql
+++ b/macros/apply_snowflake_tags.sql
@@ -314,7 +314,36 @@
    ============================================================ #}
 {% macro call_certified_read_proc() %}
     {% if execute %}
-        {{ log("Calling GRANT_CERTIFIED_READ_ACCESS procedure to apply certified read grants", info=true) }}
-        {% do run_query("CALL OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS()") %}
+        {% set certified_objects = cp_dbt_standard_package.get_certified_consumption_objects() %}
+        {% if certified_objects | length == 0 %}
+            {{ log("No certified consumption-layer objects in this run - skipping GRANT_CERTIFIED_READ_ACCESS.", info=true) }}
+        {% else %}
+            {{ log("Calling GRANT_CERTIFIED_READ_ACCESS for " ~ certified_objects | length ~ " certified consumption object(s)", info=true) }}
+            {% do run_query("CALL OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS()") %}
+        {% endif %}
     {% endif %}
+{% endmacro %}
+
+
+{% macro get_certified_consumption_objects() %}
+    {% set certified = [] %}
+    {% if execute %}
+        {% for res in results %}
+            {% set node = res.node %}
+            {% if node.resource_type == 'model' and res.status in ['success', 'pass'] %}
+                {% set db = node.database | default('', true) | upper %}
+                {# PD builds target {DOMAIN}_CON_PD; PR previews target _PR_{N}_{DOMAIN}_CON #}
+                {% set db_root = db[:-3] if db.endswith('_PD') else db %}
+                {% if db_root.endswith('_CON') %}
+                    {% set meta_tags = node.config.get('meta', {}).get('snowflake_tags', {}) %}
+                    {% set model_tags = node.config.get('snowflake_tags', {}) %}
+                    {% set tags = meta_tags if meta_tags else model_tags %}
+                    {% if (tags.get('IS_CERTIFIED', '') | string | trim | upper) == 'TRUE' %}
+                        {% do certified.append(node.unique_id) %}
+                    {% endif %}
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+    {{ return(certified) }}
 {% endmacro %}


### PR DESCRIPTION
## Summary
- Gates the `call_certified_read_proc()` on-run-end hook so `OPS_CUR.UTIL_COMMON.GRANT_CERTIFIED_READ_ACCESS()` is only invoked when the dbt run produced at least one consumption-layer model tagged `IS_CERTIFIED = TRUE` ([DPB-2838](https://cp9.atlassian.net/browse/DPB-2838); parent epic [DPB-1402](https://cp9.atlassian.net/browse/DPB-1402) DPI 2).
- Adds `get_certified_consumption_objects()` helper that scans run `results` for successful models whose database ends in `_CON` after normalizing the `_PD` push-build suffix (`{DOMAIN}_CON_PD`), resolving tags from `config.meta.snowflake_tags` first, then `config.snowflake_tags` — same precedence as `tag_models_on_run_end`.
- When no certified consumption objects exist, the hook logs a skip message and issues no SQL — no errors or warnings.
- Bumps package version 2.6.2 → 2.6.3.

**No Terraform impact:** no procedure body changes (no `__TF_REDEPLOY__` bump), `execute_as = "OWNER"` unchanged, no new Snowflake object names (no OPA exposure). Skipping is safe because `TAG_BASED_RBAC_CERT_PROC` runs the same procedure account-wide every 360 minutes, independently of dbt runs.

**Idempotency:** the gate is a pure read of the in-memory `results` collection and the guarded procedure is itself idempotent; applying twice produces the same Snowflake state.

## Test plan
- [ ] Point a consumer that tracks `release/v2` (e.g. `analytics-ops` or `analytics-git`) at this branch temporarily: `git: "https://github.com/j-asonwang/cp-dbt-standard-package.git"`, `revision: feature/DPB-2838.conditional-certified-read-post-hook`
- [ ] Curated-only build: dbt log shows `No certified consumption-layer objects in this run - skipping GRANT_CERTIFIED_READ_ACCESS.` and **no** `CALL ... GRANT_CERTIFIED_READ_ACCESS` in `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY`
- [ ] Certified consumption build: dbt log shows `Calling GRANT_CERTIFIED_READ_ACCESS for N certified consumption object(s)` and **exactly one** CALL in QUERY_HISTORY
- [ ] Repeat the certified case as a **push build** to exercise the `_CON_PD` path, not just the PR `_PR_{N}_..._CON` path
- [ ] Revert the temporary `packages.yml` pin before merging

## Validation already run
- Isolated Jinja rendering of the actual macro source (jinja2 + `do` extension): 9 cases covering CUR-only, uncertified CON, config tag, meta-tag precedence, PR database names, failed models, non-model resources, and both gate branches — all pass.
- Full-file Jinja parse, `dbt_project.yml` YAML parse (both `on-run-end` hooks intact), `git diff --check` clean.

## Out of scope (follow-ups)
- `AGENTS.md` documents `GRANT_CERTIFIED_READ_ACCESS_BY_DOMAIN(DB, JSON)` being called by this macro with a `'DEPLOY' in (target.role | upper)` guard, plus a `call_cross_domain_read_proc` macro — neither exists on `release/v2` yet. Migrating to the domain-scoped procedure is a separate, larger story.
- `analytics-ex` and `analytics-md` pin `dbt-common-1-6`, not `release/v2`; they will not pick up this change until repinned.

Made with [Cursor](https://cursor.com)

[DPB-2838]: https://cp9.atlassian.net/browse/DPB-2838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPB-1402]: https://cp9.atlassian.net/browse/DPB-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ